### PR TITLE
6 Bug with "format code" function on blocs number with colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,21 @@ Types of changes
 
 ## [Unreleased]
 
+## [V0.2.4]
+
+### Added
+
+- Added snippets for isg cnc cycle error definition files
+
+### Fixed
+
+- Fixed format code, add blocknumbers, remove blocknumbers function for nc labels (example N10:)
+- Fixed typescript issues and namespace convention
+
+### Removed
+
 - Removed unused files
 - Removed gitlab files
-- Added snippets for isg cnc cycle error definition files
-- Fixed typescript issues and namespace convention
 
 ## [V0.2.3]
 
@@ -206,6 +217,7 @@ Types of changes
 - Initial release of the extension for testing
 
 [Unreleased]: https://github.com/isg-stuttgart/vscode-isg-cnc/compare/main...develop
+[V0.2.4]: https://github.com/isg-stuttgart/vscode-isg-cnc/compare/V0.2.3...V0.2.4
 [V0.2.3]: https://github.com/isg-stuttgart/vscode-isg-cnc/compare/V0.2.2...V0.2.3
 [V0.2.2]: https://github.com/isg-stuttgart/vscode-isg-cnc/compare/V0.2.1...V0.2.2
 [V0.2.1]: https://github.com/isg-stuttgart/vscode-isg-cnc/compare/V0.2.0...V0.2.1

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ let extensionPackage;
 const regExTechnology = new RegExp("([TFS])([0-9]+)");
 // Blocknumber regex
 const regExpBlocknumbers = new RegExp(
-    /^((\s?)((\/)|(\/[1-9]{0,2}))*?(\s*?)N[0-9]*(\s?))/
+    /^((\s?)((\/)|(\/[1-9]{0,2}))*?(\s*?)N[0-9]*[:]*(\s?))/
 );
 
 /**
@@ -449,6 +449,7 @@ function isNumeric(n: number) {
 function removeAllBlocknumbers() {
     const textEdits: vscode.TextEdit[] = [];
     const { activeTextEditor } = vscode.window;
+    let blocknumbertext : string;
     if (activeTextEditor) {
         const { document } = activeTextEditor;
         if (document) {
@@ -467,8 +468,11 @@ function removeAllBlocknumbers() {
                         document.positionAt(startPos),
                         document.positionAt(endPos)
                     );
+                    blocknumbertext = document.getText(range);
+                    if (blocknumbertext.trim().endsWith(':')){
+                        continue;
+                    }
                     textEdits.push(vscode.TextEdit.replace(range, ""));
-                    // textEdits.push(vscode.TextEdit.insert(...));
                 }
             }
             const workEdits = new vscode.WorkspaceEdit();
@@ -488,6 +492,8 @@ function removeAllBlocknumbers() {
 async function addBlocknumbers() {
     let start = 10;
     let step = 10;
+    let blocknumber = start;
+    let blocknumbertext : string;
     const textEdits: vscode.TextEdit[] = [];
     const { activeTextEditor } = vscode.window;
     if (activeTextEditor) {
@@ -541,7 +547,6 @@ async function addBlocknumbers() {
             }
 
             // add new blocknumbers
-            let blocknumber = start;
             const maximalLeadingZeros = digitCount(start + document.lineCount * step);
 
             // edit document line by line
@@ -584,6 +589,11 @@ async function addBlocknumbers() {
                         document.positionAt(startPos),
                         document.positionAt(endPos)
                     );
+                    blocknumbertext = document.getText(range);
+                    if (blocknumbertext.trim().endsWith(':')){
+                        continue;
+                    }
+
                     textEdits.push(vscode.TextEdit.replace(range, block));
                 } else {
                     textEdits.push(
@@ -847,9 +857,14 @@ export function beautify(): void {
                     // Zeile wird an der Aktuellen Position eingefügt
                     newLine = newLineForBeautifier(currentLine, currentPos);
                 }
-
-                newLine = saveBlockNumber + newLine;
-
+                
+                if (saveBlockNumber.trim().endsWith(":")){
+                    newLine = saveBlockNumber.trim() + newLine; 
+                }
+                else {
+                    newLine = saveBlockNumber + newLine;
+                }
+                
                 textEdits.push(vscode.TextEdit.replace(line.range, newLine));
             }
         }


### PR DESCRIPTION
# Pull Request

## Description

Fixed format code, add blocknumbers, remove blocknumbers functions in case of nc labels like N10:. 
Formating code calculates now correct indent.
Remove blocknumbers did not delete nc label blocknumbers anymore.
NC Labels will not be changed by adding blocknumbers function.

Fixes #6

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested Format code, add blocknumbers, remove blocknumbers with following code:

```isg-nc
%goto
N05 P1=1
N06 P2=1
N10 G74 X1 Y2 Z3
N11 X0 Y0 Z0
N15 $IF P1==1 $GOTO N40: ;   Sprung von aussen nach N40 in einen
;   Steuerblock
N20 X10
N25 Y10
N30 $IF P1==2
N35 X20
N40:   $IF P2==1
N45 X30
N50: Y30 $GOTO N65: ;   Sprung nach N65 zwischen Steuersatzebenen
;   IF-ELSE
N51   $ENDIF
N55 $ELSE
N60 Y40
N65: X40
N70 $ENDIF
N80 Z99
N999 M30
```
