### PR TITLE
33 more restrictions for locale configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
             }
         },
         "configuration": {
-            "title": "ISG CNC Configuration",
+            "title": "ISG CNC",
             "type": "object",
             "properties": {
                 "isg-cnc.locale": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
                 "isg-cnc.locale": {
                     "type": "string",
                     "default": "de-DE",
-                    "description": "Choose the documentation language (en-GB, de-DE ...)"
+                    "enum": ["de-DE", "en-GB"],
+                    "description": "Choose the documentation language"
                 },
                 "isg-cnc.browser-windows": {
                     "type": "string",


### PR DESCRIPTION
 Changed locale- configuration to enum-dropdown-menu to only allow the supported de-DE and en-GB