### PR TITLE
add toLowerCase for nc file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes
 
 ### Fixed
 
+- Add toLowerCase for nc file detection
+
 ## [V0.3.4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,14 +45,14 @@ Types of changes
 - Fix lack of usability in the Extension Configuration-Settings (default browser and language) [Issue #32 reported by jurekseverin-isg](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/32) and [Issue #33 reported by jurekseverin-isg](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/33)
 - Fix bug, where Error occured when calling ISG-commands while no .nc-file is opened [Issue #30 reported by jurekseverin-isg](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/30)
 
-
 ## [V0.2.8]
 
 ### Added
 
 ### Fixed
 
-- Fix syntax highlighting for .lis files after change to standard scopes in themes. [Issue #26 reported by lukashettler-isg](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/26) 
+- Fix syntax highlighting for .lis files after change to standard scopes in themes. [Issue #26 reported by lukashettler-isg](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/26)
+
 ## [V0.2.7]
 
 ### Added

--- a/src/cncView/FileContentTree.ts
+++ b/src/cncView/FileContentTree.ts
@@ -444,5 +444,5 @@ function getLine(file: string, lineNumber: number): string {
  * @returns true if given uri ends with.nc, false otherwise
  */
 function isNcFile(path: string): boolean {
-    return Path.extname(path) === ".nc";
+    return Path.extname(path.toLowerCase()) === ".nc";
 }


### PR DESCRIPTION
Linux is case sensitive so we need to change to lower case for path verifications