### PR TITLE
Fix bug in recursive file search

### DIFF
--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -109,6 +109,10 @@ export function findFileInRootDir(rootPath: string, fileName: string): string | 
         const entryPath = path.join(rootPath, entry.name);
         if (entry.isDirectory()) { //search in subdirectory
             res = findFileInRootDir(entryPath, fileName);
+            //if file found, stop searching
+            if (res) {
+                break;
+            }
         } else if (entry.isFile() && entry.name === fileName) { //file found
             res = entryPath;
             break;


### PR DESCRIPTION
The recursive function for file search did overwrite a found file with null when having multiple folders. This is fixed now by breaking when the file is found.