### PR TITLE
Added requested higlighting for #START/LOCK/UNLOCK and V.I-Variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Types of changes:
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Syntax highlighting for `#START`, `#LOCK`and `#UNLOCK` commands and `V.I.`-Variables [Issue #151](https://github.com/isg-stuttgart/vscode-isg-cnc/issues/151)
 
 ## [V1.0.0]
 

--- a/syntaxes/isg-cnc.tmLanguage.json
+++ b/syntaxes/isg-cnc.tmLanguage.json
@@ -404,6 +404,14 @@
                     "name": "keyword.other.hashtagcommand"
                 },
                 {
+                    "match": "#LOCK",
+                    "name": "keyword.other.hashtagcommand"
+                },
+                {
+                    "match": "#UNLOCK",
+                    "name": "keyword.other.hashtagcommand"
+                },
+                {
                     "match": "\\#MACHINE\\s*?*DATA",
                     "name": "keyword.other.hashtagcommand"
                 },
@@ -517,6 +525,10 @@
                 },
                 {
                     "match": "\\#SUPPRESS\\s*?*OFFSETS",
+                    "name": "keyword.other.hashtagcommand"
+                },
+                {
+                    "match": "#START",
                     "name": "keyword.other.hashtagcommand"
                 },
                 {
@@ -777,6 +789,10 @@
                 },
                 {
                     "match": "V\\.CYC\\.[.a-zA-Z0-9_]+",
+                    "name": "variable.language"
+                },
+                {
+                    "match": "V\\.I\\.[.a-zA-Z0-9_]+",
                     "name": "variable.language"
                 },
                 {

--- a/themes/isg-cnc.color-theme-dark.json
+++ b/themes/isg-cnc.color-theme-dark.json
@@ -6,10 +6,10 @@
         "activityBarBadge.background": "#007acc",
         "editor.background": "#1e1e1e",
         "editor.foreground": "#d4d4d4",
-        "editor.inactiveSelectionBackground": "#3a3d41",
+        "editor.inactiveSelectionBackground": "#3a3d4163",
         "editor.selectionHighlightBackground": "#add6ff26",
-        "editorIndentGuide.activeBackground": "#707070",
-        "editorIndentGuide.background": "#404040",
+        "editorIndentGuide.activeBackground1": "#707070",
+        "editorIndentGuide.background1": "#404040",
         "input.placeholderForeground": "#a6a6a6",
         "list.dropBackground": "#383b3d",
         "menu.background": "#252526",
@@ -108,21 +108,21 @@
             }
         },
         {
-            "scope" : "variable.parameter",
+            "scope": "variable.parameter",
             "settings": {
                 "foreground": "#e523ff",
                 "fontStyle": ""
             }
         },
         {
-            "scope" : "variable.language",
+            "scope": "variable.language",
             "settings": {
                 "foreground": "#e523ff",
                 "fontStyle": ""
             }
         },
         {
-            "scope" : "string.quoted.double",
+            "scope": "string.quoted.double",
             "settings": {
                 "foreground": "#96712d",
                 "fontStyle": ""


### PR DESCRIPTION
I just added the requested syntax highlighting.
The changes i made to the color codes in the themes-json-file are because of vscode-intellisense-suggestions that these should be transparent.