### PR TITLE
Fix correctness, performance and security issues across client, serve…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,9 @@
     "ignorePatterns": [
         "out",
         "dist",
-        "**/*.d.ts"
+        "**/*.d.ts",
+        "server/src/parserGenerating/ncParser.ts",
+        "server/src/parserGenerating/generateParser.js",
+        "server/src/parserGenerating/debugParser.ts"
     ]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 on:
-  push:    
+  workflow_dispatch:
+  push:
     tags:
       - "V*"
 
@@ -9,17 +10,20 @@ jobs:
   deploy_extension:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      # Note: for a hardened, secret-bearing workflow consider pinning these actions to a full commit SHA.
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: npm ci
+      # quality gate: never publish a build that does not compile or lint
+      - run: npm run pretest
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
 #      - name: Publish to Open VSX Registry
-#        uses: HaaLeo/publish-vscode-extension@v0
+#        uses: HaaLeo/publish-vscode-extension@v1
 #        with:
 #          pat: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Extension Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
@@ -10,11 +10,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     name: Test on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           check-latest: true
           cache: "npm"
           cache-dependency-path: package-lock.json

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Visual Studio Code V1.73.1 or higher
   - Command to change the language mode of a file or whole directory (accessible via right-click menu, not in the ISG Command Submenu)
   - Encrypt files by key
 
+    > **Note:** The file encryption uses the Blowfish algorithm to stay compatible with the encrypted
+    > file format expected by the ISG-CNC kernel (e.g. `.ecy` files). It is meant for format
+    > compatibility, not as a strong, general-purpose security feature.
+
 ## Feature Details
 ### Sub Program Comments
 You can define doc comments for your subprograms, cycles, Goto-Labels, Goto-Blocknumber, variables like this:

--- a/package.json
+++ b/package.json
@@ -518,7 +518,8 @@
         "compile": "tsc -p ./ && tsc -p ./server",
         "watch": "tsc -watch -p ./ && tsc -watch -p ./server",
         "pretest": "npm run compile && npm run lint",
-        "lint": "eslint src --ext ts",
+        "lint": "eslint src server/src --ext ts --max-warnings 0",
+        "generateParser": "node ./server/src/parserGenerating/generateParser.js",
         "test": "node ./out/src/test/runTest.js",
         "postinstall": "cd server && npm install"
     },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,12 +24,14 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -68,9 +70,10 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"license": "ISC"
 		},
 		"node_modules/fs-extra": {
 			"version": "8.1.0",
@@ -122,11 +125,12 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -5,7 +5,7 @@ import * as ls from 'vscode-languageserver';
 import { Match, Position } from './parserClasses';
 import { Cycle, getCycles } from '../extension-resources-output/src/cycles';
 import { findMatchesWithinPrgTree, findPreciseMatchOfTypes } from './parserSearching';
-import { ParseResults } from './parsingResults';
+import { getParseResults } from './parsingResults';
 import path = require('path');
 import { MatchType } from './matchTypes';
 import { ItemKind, JsonEntry } from '../extension-resources-output/src/JsonEntry';
@@ -55,12 +55,19 @@ export function updateStaticGeneralCompletions(): void {
  * @returns the completions for the given position 
  */
 export function getCompletions(pos: Position, doc: TextDocument): CompletionItem[] {
-    const cycleCompletions = getCycleCompletions(pos, doc);
+    let cycleCompletions: CompletionItem[] = [];
+    try {
+        cycleCompletions = getCycleCompletions(pos, doc);
+    } catch (error) {
+        // a parse failure (e.g. the grammar timeout on very large files) must not suppress the
+        // static general completions as well
+        console.error("Failed to compute cycle completions: " + error);
+    }
     return [...staticGeneralCompletions, ...cycleCompletions];
 }
 
 export function getCycleCompletions(pos: Position, doc: TextDocument): CompletionItem[] {
-    const parseResults: ParseResults = new ParseResults(doc.getText());
+    const parseResults = getParseResults(doc.getText());
     // if the position is within a cycle call, get the completions for the cycle
     const cycle = findPreciseMatchOfTypes(parseResults.results.fileTree, pos, [MatchType.globalCycleCall]);
     const cycleCompletions = [];
@@ -81,7 +88,9 @@ export function getCycleCompletions(pos: Position, doc: TextDocument): Completio
  * @returns the replace-completions for the given position 
  */
 function getReplaceCompletion(pos: Position, doc: TextDocument, completionsToEdit: CompletionItem[], startFilter?: string): CompletionItem[] {
-    const completions = JSON.parse(JSON.stringify(completionsToEdit));
+    // shallow-copy each item so we can attach a textEdit without mutating the shared (static) items;
+    // a full JSON deep-copy of the whole list (incl. large markdown docs) on every request is wasteful
+    const completions: CompletionItem[] = completionsToEdit.map(completion => ({ ...completion }));
     let startCharacter = pos.character - 1;
     while (startCharacter >= 0) {
         const text = doc.getText(Range.create(pos.line, startCharacter, pos.line, pos.character));

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,4 +1,4 @@
-import { WorkspaceIgnorer, findMostSpecificGlobPattern, normalizePath } from "./fileSystem";
+import { WorkspaceIgnorer, findMostSpecificGlobPattern, normalizePath, HEAVY_DIRS } from "./fileSystem";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -80,19 +80,19 @@ export function cloneFileAssociations(): { [key: string]: string } {
  * - {@link locale}
  * - {@link extensionForCycles}
  * - {@link cycleSnippetFormatting}
- *
- * Updates the important settings with the setting of the IDE, namely:
- * - {@link documentationPath}
- * - {@link fileAssociations}
- * - {@link locale}
- * - {@link extensionForCycles}
- * - {@link cycleSnippetFormatting}
- *
 */
 export function updateSettings(workspaceConfig: any) {
     const failedSettings: string[] = [];
-    // update documentation path
-    documentationPath = workspaceConfig['isg-cnc']['documentationPath'];
+    // guard against a missing isg-cnc config section so a malformed config cannot crash the server
+    const isgCncConfig = workspaceConfig?.['isg-cnc'] ?? {};
+
+    // update documentation path (keep previous value if not provided)
+    if (typeof isgCncConfig['documentationPath'] === "string") {
+        documentationPath = isgCncConfig['documentationPath'];
+    } else {
+        failedSettings.push("documentationPath");
+    }
+
     // update file associations
     try {
         const newFileAssociations: { [key: string]: string } = workspaceConfig['files']['associations'];
@@ -112,77 +112,34 @@ export function updateSettings(workspaceConfig: any) {
     }
 
     // update extension for cycles
-    extensionForCycles = workspaceConfig['isg-cnc']['extensionForCycles'];
+    if (typeof isgCncConfig['extensionForCycles'] === "string") {
+        extensionForCycles = isgCncConfig['extensionForCycles'];
+    } else {
+        failedSettings.push("extensionForCycles");
+    }
 
     // update locale
-    try {
-        switch (workspaceConfig['isg-cnc']['locale']) {
-            case "en-GB":
-                locale = Locale.en;
-                break;
-            case "de-DE":
-                locale = Locale.de;
-                break;
-            default:
-                throw new Error("Invalid isg-cnc.locale");
-        }
-    } catch (error) {
-        failedSettings.push("locale");
+    switch (isgCncConfig['locale']) {
+        case "en-GB":
+            locale = Locale.en;
+            break;
+        case "de-DE":
+            locale = Locale.de;
+            break;
+        default:
+            failedSettings.push("locale");
     }
 
     // update cycle snippet formatting
-    try {
-        switch (workspaceConfig['isg-cnc']['cycleSnippetFormatting']) {
-            case "multi-line":
-                cycleSnippetFormatting = CycleSnippetFormatting.multiLine;
-                break;
-            case "single-line":
-                cycleSnippetFormatting = CycleSnippetFormatting.singleLine;
-                break;
-            default:
-                throw new Error("Invalid isg-cnc.cycleSnippetFormatting");
-        }
-    } catch (error) {
-        failedSettings.push("cycleSnippetFormatting");
-    }
-
-    if (failedSettings.length > 0) {
-        throw new Error("Failed to update settings: " + failedSettings.join(", "));
-    }
-
-    // update extension for cycles
-    extensionForCycles = workspaceConfig['isg-cnc']['extensionForCycles'];
-
-    // update locale
-    try {
-        switch (workspaceConfig['isg-cnc']['locale']) {
-            case "en-GB":
-                locale = Locale.en;
-                break;
-            case "de-DE":
-                locale = Locale.de;
-                break;
-            default:
-                throw new Error("Invalid isg-cnc.locale");
-        }
-    } catch (error) {
-        failedSettings.push("locale");
-    }
-
-    // update cycle snippet formatting
-    try {
-        switch (workspaceConfig['isg-cnc']['cycleSnippetFormatting']) {
-            case "multi-line":
-                cycleSnippetFormatting = CycleSnippetFormatting.multiLine;
-                break;
-            case "single-line":
-                cycleSnippetFormatting = CycleSnippetFormatting.singleLine;
-                break;
-            default:
-                throw new Error("Invalid isg-cnc.cycleSnippetFormatting");
-        }
-    } catch (error) {
-        failedSettings.push("cycleSnippetFormatting");
+    switch (isgCncConfig['cycleSnippetFormatting']) {
+        case "multi-line":
+            cycleSnippetFormatting = CycleSnippetFormatting.multiLine;
+            break;
+        case "single-line":
+            cycleSnippetFormatting = CycleSnippetFormatting.singleLine;
+            break;
+        default:
+            failedSettings.push("cycleSnippetFormatting");
     }
 
     if (failedSettings.length > 0) {
@@ -195,19 +152,22 @@ export function updateSettings(workspaceConfig: any) {
  * This includes all files which the client considers to be isg-cnc files and exludes the one ignored by the .isg-cnc-ignore file within the root path (if existing).
  * @param root the root directory to start searching in (most likely a workspace root)
  */
-export function getAllNotIgnoredCncFilePathsInRoot(root: string): string[] {
+export function getAllNotIgnoredCncFilePathsInRoot(root: string, dir: string = root, ignorer: WorkspaceIgnorer = new WorkspaceIgnorer(root)): string[] {
     const paths: string[] = [];
-    const dirEntries = fs.readdirSync(root, { withFileTypes: true });
-    const ignorer = new WorkspaceIgnorer(root);
+    const dirEntries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of dirEntries) {
-        const entryPath = path.join(root, entry.name);
+        const entryPath = path.join(dir, entry.name);
         // skip ignored files/folders
         if (ignorer.ignores(entryPath)) {
             continue;
         }
         if (entry.isDirectory()) {
-            //search in subdirectory
-            paths.push(...getAllNotIgnoredCncFilePathsInRoot(entryPath));
+            // skip large directories that never contain relevant NC files
+            if (HEAVY_DIRS.has(entry.name)) {
+                continue;
+            }
+            //search in subdirectory, reusing the ignorer created for this root
+            paths.push(...getAllNotIgnoredCncFilePathsInRoot(root, entryPath, ignorer));
         } else if (entry.isFile() && isCncFile(entryPath)) {
             //file found
             const normPath = normalizePath(entryPath);

--- a/server/src/fileSystem.ts
+++ b/server/src/fileSystem.ts
@@ -58,15 +58,40 @@ export function findFileInRootDir(rootPath: string, fileName: string, ignorer: W
             continue;
         }
         if (entry.isDirectory()) {
+            // skip large directories that never contain relevant NC files
+            if (HEAVY_DIRS.has(entry.name)) {
+                continue;
+            }
             //search in subdirectory
             paths.push(...findFileInRootDir(entryPath, fileName, ignorer, needsToBeCNCFile));
-        } else if (entry.isFile() && entry.name === fileName && (!needsToBeCNCFile || isCncFile(entryPath))) {
+        } else if (entry.isFile() && fileNamesMatch(entry.name, fileName) && (!needsToBeCNCFile || isCncFile(entryPath))) {
             //file found
             const normPath = normalizePath(entryPath);
             paths.push(normPath);
         }
     }
     return paths;
+}
+
+/** Directories that never contain relevant NC files and would only slow down the recursive file search. */
+export const HEAVY_DIRS = new Set([".git", "node_modules", ".svn", ".hg"]);
+
+/**
+ * Compares two file names. On Windows the file system is case-insensitive, so "SUB.NC" and "sub.nc"
+ * refer to the same file; on POSIX the comparison stays case-sensitive.
+ */
+function fileNamesMatch(a: string, b: string): boolean {
+    return process.platform === "win32" ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+/** Returns whether the given path is absolute on either Windows or POSIX. */
+export function isAbsoluteCrossPlatform(p: string): boolean {
+    return path.win32.isAbsolute(p) || path.posix.isAbsolute(p);
+}
+
+/** Returns the base name of the given path, handling both Windows and POSIX separators. */
+export function basenameCrossPlatform(p: string): string {
+    return path.win32.isAbsolute(p) ? path.win32.basename(p) : path.posix.basename(p);
 }
 
 /**

--- a/server/src/getDefinitionAndReferences.ts
+++ b/server/src/getDefinitionAndReferences.ts
@@ -7,13 +7,12 @@ import {
     findMatchRangesWithinPath,
 } from "./parserSearching";
 import * as fs from "fs";
-import path = require("node:path");
 import { Connection } from "vscode-languageserver";
 import { getSurroundingVar, findLocalStringRanges, isWithinMatches } from "./stringSearching";
-import { WorkspaceIgnorer, findFileInRootDir, normalizePath } from "./fileSystem";
+import { WorkspaceIgnorer, findFileInRootDir, normalizePath, isAbsoluteCrossPlatform, basenameCrossPlatform } from "./fileSystem";
 import { getDefType, getRefTypes, MatchType } from "./matchTypes";
 import { getAllNotIgnoredCncFilePathsInRoot } from "./config";
-import { ParseResults } from "./parsingResults";
+import { ParseResults, getParseResults } from "./parsingResults";
 import { LocationRange } from "peggy";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
@@ -70,8 +69,9 @@ export function getDefinition(parseResults: ParseResults, position: Position, ur
         definitions.push(new FileRange(uri, start, end));
     } else if (rootPaths && [MatchType.globalPrgCall, MatchType.globalCycleCall].includes(defType)) {
         let defPaths: string[] = [];
-        // if the call contains a valid absolute path, use it
-        if (path.isAbsolute(match.name)) {
+        // if the call contains a valid absolute path, use it (NC code usually contains Windows paths,
+        // so check both Windows and POSIX absoluteness regardless of the server platform)
+        if (isAbsoluteCrossPlatform(match.name)) {
             const normPath = normalizePath(match.name);
             if (fs.existsSync(normPath)) {
                 defPaths.push(normalizePath(match.name));
@@ -88,11 +88,13 @@ export function getDefinition(parseResults: ParseResults, position: Position, ur
             const defFileContent = openDocs.get(uri)?.getText() ?? fs.readFileSync(path, "utf8");
             let mainPrgLoc: LocationRange | null = null;
             try {
-                const parseResults = new ParseResults(defFileContent);
+                const parseResults = getParseResults(defFileContent);
                 parsedDocs.set(uri, parseResults);
                 mainPrgLoc = parseResults.results.mainPrgLoc;
             } catch (error) {
-                throw new Error(`Error parsing file ${uri}: ${error}`);
+                // skip files that cannot be parsed instead of failing the whole definition lookup
+                console.error(`Error parsing file ${uri}: ${error}`);
+                continue;
             }
             let range = {
                 start: new Position(0, 0),
@@ -124,7 +126,7 @@ export async function getReferences(fileContent: string, position: Position, uri
     // parse the file content and search for the selected position
     let parseResult: ParseResults;
     try {
-        parseResult = new ParseResults(fileContent);
+        parseResult = getParseResults(fileContent);
     } catch (error) {
         throw new Error(`Error parsing file ${uri}: ${error}`);
     }
@@ -137,7 +139,9 @@ export async function getReferences(fileContent: string, position: Position, uri
     // if the selected position is a variable use string search to find all references and return the result
     const surroundingVar = getSurroundingVar(fileContent, position);
     if (surroundingVar) {
-        const stringRanges = findLocalStringRanges(fileContent, surroundingVar, uri);
+        // reuse the already parsed comments instead of parsing the file a second time; use whole-word
+        // matching so V.P.FOO does not match inside a longer variable name like V.P.FOOBAR
+        const stringRanges = findLocalStringRanges(fileContent, surroundingVar, uri, parseResult.syntaxArray.comments, true);
         return stringRanges;
     }
 
@@ -151,8 +155,9 @@ export async function getReferences(fileContent: string, position: Position, uri
     let name: string = match.name;
 
     // if the match is a global program name or cycle call name and absolute path is given, add the filename to the search names
-    if (rootPaths && [MatchType.globalPrgCallName, MatchType.globalCycleCallName].includes(match.type) && path.isAbsolute(match.name)) {
-        name = path.basename(match.name);
+    // (handle Windows and POSIX paths regardless of the server platform)
+    if (rootPaths && [MatchType.globalPrgCallName, MatchType.globalCycleCallName].includes(match.type) && isAbsoluteCrossPlatform(match.name)) {
+        name = basenameCrossPlatform(match.name);
     }
 
     // if local find all references in the same file and add their ranges to the result array
@@ -170,8 +175,12 @@ export async function getReferences(fileContent: string, position: Position, uri
         // create a progress bar and search for references in all isg-cnc files
         const progress = await connection.window.createWorkDoneProgress();
         const progressHandler = new IncrementableProgress(progress, isgCncFiles.length, "Searching references");
-        referenceRanges.push(...findMatchRangesWithinPath(isgCncFiles, refTypes, name, openFiles, progressHandler));
-        progressHandler.done();
+        // ensure the progress bar is always closed, even if the search throws
+        try {
+            referenceRanges.push(...await findMatchRangesWithinPath(isgCncFiles, refTypes, name, openFiles, progressHandler));
+        } finally {
+            progressHandler.done();
+        }
     }
 
     return referenceRanges;

--- a/server/src/hover.ts
+++ b/server/src/hover.ts
@@ -1,7 +1,7 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { isMatch, Match, Position } from "./parserClasses";
 import { findPreciseMatchOfTypes } from "./parserSearching";
-import { ParseResults } from "./parsingResults";
+import { ParseResults, getParseResults } from "./parsingResults";
 import { Hover, Range } from "vscode-languageserver";
 import { getCycles, getISGCycleByName } from "../extension-resources-output/src/cycles";
 import path = require("path");
@@ -25,7 +25,7 @@ const jsonEntries: JsonEntry[] = JsonEntry.parseJsonList([...rawJsonData, ...raw
 export function getHoverInformation(position: Position, textDocument: TextDocument, rootPaths: string[] | null, openDocs: Map<string, TextDocument>): Hover | null {
     // parse to check which type of hover information is needed
     // supported types are cycle call, cycle parameter, subprogram call, GOTO, variable
-    const parseResults: ParseResults = new ParseResults(textDocument.getText());
+    const parseResults: ParseResults = getParseResults(textDocument.getText());
     const ast = parseResults.results.fileTree;
     const match = findPreciseMatchOfTypes(ast, position, [
         MatchType.localPrgDefinitionName,
@@ -53,7 +53,8 @@ export function getHoverInformation(position: Position, textDocument: TextDocume
     // basic hover content containing the name and what hover type it is
     const callType = getHoverTypeString(match);
     const name = [MatchType.blockNumberLabel, MatchType.gotoBlocknumber].includes(match.type) ? "N" + match.name : match.name;
-    let hoverContent = `**${name}** ${callType}\n\n`;
+    const baseHeader = `**${name}** ${callType}\n\n`;
+    let hoverContent = baseHeader;
     let commentOffset = -1;
     let defDocument = textDocument;
     let defTree = ast;
@@ -73,7 +74,7 @@ export function getHoverInformation(position: Position, textDocument: TextDocume
             commentOffset = findFirstNonWhitespaceOffsetAfter(varDefResults.defDoc, varDefResults.defFileRange.range.end);
             const lineComment = findPreciseMatchOfTypes(varDefResults.defParseResults.results.fileTree, varDefResults.defDoc.positionAt(commentOffset), [MatchType.lineComment]);
             if (lineComment) {
-                hoverContent += `${lineComment.content}\n\n`;
+                hoverContent += `${escapeMarkdownLinks(lineComment.content)}\n\n`;
             }
         }
         // comment searching done for variable
@@ -129,29 +130,28 @@ export function getHoverInformation(position: Position, textDocument: TextDocume
         hoverContent += `File Location: [${defDocument.uri}](${defDocument.uri})`;
     }
     // return hover element
-    let hover: Hover | null = null;
-    if (hoverContent !== "") {
-        hover = {
-            contents: {
-                kind: "markdown",
-                value: hoverContent
+    const headerHover: Hover = {
+        contents: {
+            kind: "markdown",
+            value: hoverContent
+        },
+        range: {
+            start: {
+                line: match.location.start.line - 1,
+                character: match.location.start.column - 1
             },
-            range: {
-                start: {
-                    line: match.location.start.line - 1,
-                    character: match.location.start.column - 1
-                },
-                end: {
-                    line: match.location.end.line - 1,
-                    character: match.location.end.column - 1
-                }
+            end: {
+                line: match.location.end.line - 1,
+                character: match.location.end.column - 1
             }
-        };
-    } else {
-        // try to get static pattern based hover information from json entries
-        hover = getStaticPatternBasedHoverInformation(position, textDocument);
+        }
+    };
+    // if we found documentation (or a cross-file link), show it; otherwise fall back to the
+    // static pattern based hover information and only use the bare header if that yields nothing
+    if (hoverContent !== baseHeader) {
+        return headerHover;
     }
-    return hover;
+    return getStaticPatternBasedHoverInformation(position, textDocument) ?? headerHover;
 }
 
 function getStaticPatternBasedHoverInformation(position: Position, textDocument: TextDocument): Hover | null {
@@ -354,12 +354,12 @@ function getMarkdownDocumentationOfPrgDoc(commentMatch: Match): string {
     for (const contentItem of commentMatch.content) {
         if (isMatch(contentItem)) {// contentItem is a special comment like a @param or @return
             const matchTypeString = contentItem.type.slice(0, -3); // remove "Doc" suffix
-            const nameString = contentItem.name ? ` \`\`\`${contentItem.name}\`\`\` ` : "";
-            const infoText = contentItem.content ? ` — ${contentItem.content}` : "";
+            const nameString = contentItem.name ? ` \`\`\`${escapeMarkdownLinks(contentItem.name)}\`\`\` ` : "";
+            const infoText = contentItem.content ? ` — ${escapeMarkdownLinks(contentItem.content)}` : "";
             markdown += `*@${matchTypeString}*${nameString}${infoText}`;
         }
         else if (typeof contentItem === "string") { // contentItem is a simple comment
-            markdown += `${contentItem}`;
+            markdown += `${escapeMarkdownLinks(contentItem)}`;
         }
         else { // otherwise skip
             continue;
@@ -367,5 +367,14 @@ function getMarkdownDocumentationOfPrgDoc(commentMatch: Match): string {
         markdown += "\n\n";
     }
     return markdown;
+}
+
+/**
+ * Escapes characters in file-derived comment text that could otherwise form a clickable
+ * markdown/command link. This is defense-in-depth on top of the markdown "enabledCommands"
+ * restriction configured on the client.
+ */
+function escapeMarkdownLinks(text: string): string {
+    return text.replace(/[[\]<>]/g, (c) => "\\" + c);
 }
 

--- a/server/src/parserGenerating/generateParser.js
+++ b/server/src/parserGenerating/generateParser.js
@@ -16,5 +16,7 @@ try {
     fs.writeFileSync('./server/src/parserGenerating/ncParser.ts', parser);
 } catch (error) {
     console.error(error);
+    // fail loudly so a broken grammar is caught in the build/CI instead of silently producing nothing
+    process.exit(1);
 }
 

--- a/server/src/parserGenerating/ncGrammar.pegjs
+++ b/server/src/parserGenerating/ncGrammar.pegjs
@@ -167,7 +167,7 @@ block "block"                                               // an NC block
 }
 
 skipped_block "skipped_block"                               // a skipped nc block
-= content:("/"(digit/"10")?  grayspaces block_body){
+= content:("/"("10"/digit)?  grayspaces block_body){
     return new Match(types.skipBlock, content, location(), text(), null);
 }
 
@@ -400,7 +400,7 @@ label                                                       // a label to which 
 
 data_type = 
   $("BOOLEAN"/"SGN08"/"UNS08"/"SGN16"/"UNS16"/"SGN32"/"UNS32"/"REAL"/
-  ("STRING[" (("12"[0-6]) / ("1"[01][1-9]) / ([1-9][0-9]) / ([0-9]))  "]")) // STRING[i] with i = 1...126
+  ("STRING[" (("12"[0-6]) / ("1"[01]"0") / ("1"[01][1-9]) / ([1-9][0-9]) / ([0-9]))  "]")) // STRING[i] with i = 1...126 (longer alternatives first so ordered choice reaches 100/110/120-126)
 
 
 var_dec_name

--- a/server/src/parserGenerating/ncParser.ts
+++ b/server/src/parserGenerating/ncParser.ts
@@ -544,81 +544,83 @@ function peg$parse(input: string, options?: ParseOptions) {
   const peg$c177 = peg$literalExpectation("1", false);
   const peg$c178 = /^[01]/;
   const peg$c179 = peg$classExpectation(["0", "1"], false, false);
-  const peg$c180 = /^[1-9]/;
-  const peg$c181 = peg$classExpectation([["1", "9"]], false, false);
-  const peg$c182 = /^[0-9]/;
-  const peg$c183 = peg$classExpectation([["0", "9"]], false, false);
-  const peg$c184 = "V.";
-  const peg$c185 = peg$literalExpectation("V.", false);
-  const peg$c186 = "S";
-  const peg$c187 = peg$literalExpectation("S", false);
-  const peg$c188 = "CYC";
-  const peg$c189 = peg$literalExpectation("CYC", false);
-  const peg$c190 = function(): any {
+  const peg$c180 = "0";
+  const peg$c181 = peg$literalExpectation("0", false);
+  const peg$c182 = /^[1-9]/;
+  const peg$c183 = peg$classExpectation([["1", "9"]], false, false);
+  const peg$c184 = /^[0-9]/;
+  const peg$c185 = peg$classExpectation([["0", "9"]], false, false);
+  const peg$c186 = "V.";
+  const peg$c187 = peg$literalExpectation("V.", false);
+  const peg$c188 = "S";
+  const peg$c189 = peg$literalExpectation("S", false);
+  const peg$c190 = "CYC";
+  const peg$c191 = peg$literalExpectation("CYC", false);
+  const peg$c192 = function(): any {
     return new Match(types.variable, text(), location(), text(), text()) 
   };
-  const peg$c191 = peg$otherExpectation("grayspace");
-  const peg$c192 = peg$otherExpectation("grayspaces");
-  const peg$c193 = peg$otherExpectation("grayline");
-  const peg$c194 = peg$otherExpectation("comment");
-  const peg$c195 = peg$otherExpectation("line_comment");
-  const peg$c196 = peg$otherExpectation("paren_comment");
-  const peg$c197 = "(";
-  const peg$c198 = peg$literalExpectation("(", false);
-  const peg$c199 = /^[^)\r\n]/;
-  const peg$c200 = peg$classExpectation([")", "\r", "\n"], true, false);
-  const peg$c201 = ")";
-  const peg$c202 = peg$literalExpectation(")", false);
-  const peg$c203 = function(content: any): any { return new Match(types.lineComment, content.trim(), location(), text(), null)};
-  const peg$c204 = peg$otherExpectation("semicolon_comment");
-  const peg$c205 = ";";
-  const peg$c206 = peg$literalExpectation(";", false);
-  const peg$c207 = /^[^\r\n]/;
-  const peg$c208 = peg$classExpectation(["\r", "\n"], true, false);
-  const peg$c209 = peg$otherExpectation("block_comment");
-  const peg$c210 = peg$otherExpectation("whitespace");
-  const peg$c211 = /^[\t ]/;
-  const peg$c212 = peg$classExpectation(["\t", " "], false, false);
-  const peg$c213 = peg$otherExpectation("whitespaces");
-  const peg$c214 = function(): any {return text()};
-  const peg$c215 = peg$otherExpectation("linebreak");
-  const peg$c216 = "\r\n";
-  const peg$c217 = peg$literalExpectation("\r\n", false);
-  const peg$c218 = peg$otherExpectation("non_linebreak");
-  const peg$c219 = /^[^\n\r]/;
-  const peg$c220 = peg$classExpectation(["\n", "\r"], true, false);
-  const peg$c221 = peg$otherExpectation("integer");
-  const peg$c222 = "-";
-  const peg$c223 = peg$literalExpectation("-", false);
-  const peg$c224 = peg$otherExpectation("non_neg_integer");
-  const peg$c225 = peg$otherExpectation("number");
-  const peg$c226 = peg$otherExpectation("name");
-  const peg$c227 = /^[_a-zA-Z0-9.]/;
-  const peg$c228 = peg$classExpectation(["_", ["a", "z"], ["A", "Z"], ["0", "9"], "."], false, false);
-  const peg$c229 = peg$otherExpectation("digit");
-  const peg$c230 = peg$otherExpectation("non_delimiter");
-  const peg$c231 = /^[^\t ();"[\],#$\n\r]/;
-  const peg$c232 = peg$classExpectation(["\t", " ", "(", ")", ";", "\"", "[", "]", ",", "#", "$", "\n", "\r"], true, false);
-  const peg$c233 = peg$otherExpectation("string");
-  const peg$c234 = /^[^"]/;
-  const peg$c235 = peg$classExpectation(["\""], true, false);
-  const peg$c236 = peg$otherExpectation("program_doc_block_comment");
-  const peg$c237 = "#COMMENT";
-  const peg$c238 = peg$literalExpectation("#COMMENT", false);
-  const peg$c239 = "BEGIN";
-  const peg$c240 = peg$literalExpectation("BEGIN", false);
-  const peg$c241 = function(content: any): any { return new Match(types.blockComment, content, location(), text(), null)};
-  const peg$c242 = peg$otherExpectation("program_doc_block_comment_body");
-  const peg$c243 = peg$otherExpectation("program_doc_block_comment_body_special_case");
-  const peg$c244 = peg$otherExpectation("program_doc_block_comment_body_keyword_line");
-  const peg$c245 = function(keyword: any, name: any, rest: any): any { 
+  const peg$c193 = peg$otherExpectation("grayspace");
+  const peg$c194 = peg$otherExpectation("grayspaces");
+  const peg$c195 = peg$otherExpectation("grayline");
+  const peg$c196 = peg$otherExpectation("comment");
+  const peg$c197 = peg$otherExpectation("line_comment");
+  const peg$c198 = peg$otherExpectation("paren_comment");
+  const peg$c199 = "(";
+  const peg$c200 = peg$literalExpectation("(", false);
+  const peg$c201 = /^[^)\r\n]/;
+  const peg$c202 = peg$classExpectation([")", "\r", "\n"], true, false);
+  const peg$c203 = ")";
+  const peg$c204 = peg$literalExpectation(")", false);
+  const peg$c205 = function(content: any): any { return new Match(types.lineComment, content.trim(), location(), text(), null)};
+  const peg$c206 = peg$otherExpectation("semicolon_comment");
+  const peg$c207 = ";";
+  const peg$c208 = peg$literalExpectation(";", false);
+  const peg$c209 = /^[^\r\n]/;
+  const peg$c210 = peg$classExpectation(["\r", "\n"], true, false);
+  const peg$c211 = peg$otherExpectation("block_comment");
+  const peg$c212 = peg$otherExpectation("whitespace");
+  const peg$c213 = /^[\t ]/;
+  const peg$c214 = peg$classExpectation(["\t", " "], false, false);
+  const peg$c215 = peg$otherExpectation("whitespaces");
+  const peg$c216 = function(): any {return text()};
+  const peg$c217 = peg$otherExpectation("linebreak");
+  const peg$c218 = "\r\n";
+  const peg$c219 = peg$literalExpectation("\r\n", false);
+  const peg$c220 = peg$otherExpectation("non_linebreak");
+  const peg$c221 = /^[^\n\r]/;
+  const peg$c222 = peg$classExpectation(["\n", "\r"], true, false);
+  const peg$c223 = peg$otherExpectation("integer");
+  const peg$c224 = "-";
+  const peg$c225 = peg$literalExpectation("-", false);
+  const peg$c226 = peg$otherExpectation("non_neg_integer");
+  const peg$c227 = peg$otherExpectation("number");
+  const peg$c228 = peg$otherExpectation("name");
+  const peg$c229 = /^[_a-zA-Z0-9.]/;
+  const peg$c230 = peg$classExpectation(["_", ["a", "z"], ["A", "Z"], ["0", "9"], "."], false, false);
+  const peg$c231 = peg$otherExpectation("digit");
+  const peg$c232 = peg$otherExpectation("non_delimiter");
+  const peg$c233 = /^[^\t ();"[\],#$\n\r]/;
+  const peg$c234 = peg$classExpectation(["\t", " ", "(", ")", ";", "\"", "[", "]", ",", "#", "$", "\n", "\r"], true, false);
+  const peg$c235 = peg$otherExpectation("string");
+  const peg$c236 = /^[^"]/;
+  const peg$c237 = peg$classExpectation(["\""], true, false);
+  const peg$c238 = peg$otherExpectation("program_doc_block_comment");
+  const peg$c239 = "#COMMENT";
+  const peg$c240 = peg$literalExpectation("#COMMENT", false);
+  const peg$c241 = "BEGIN";
+  const peg$c242 = peg$literalExpectation("BEGIN", false);
+  const peg$c243 = function(content: any): any { return new Match(types.blockComment, content, location(), text(), null)};
+  const peg$c244 = peg$otherExpectation("program_doc_block_comment_body");
+  const peg$c245 = peg$otherExpectation("program_doc_block_comment_body_special_case");
+  const peg$c246 = peg$otherExpectation("program_doc_block_comment_body_keyword_line");
+  const peg$c247 = function(keyword: any, name: any, rest: any): any { 
     const type = keyword += "Doc";
     return new Match(type, rest.trim(), location(), text(), name)
   };
-  const peg$c246 = peg$otherExpectation("comment_end");
-  const peg$c247 = "END";
-  const peg$c248 = peg$literalExpectation("END", false);
-  const peg$c249 = peg$otherExpectation("markdownLinebreak");
+  const peg$c248 = peg$otherExpectation("comment_end");
+  const peg$c249 = "END";
+  const peg$c250 = peg$literalExpectation("END", false);
+  const peg$c251 = peg$otherExpectation("markdownLinebreak");
 
   let peg$currPos = 0;
   let peg$savedPos = 0;
@@ -1488,15 +1490,15 @@ function peg$parse(input: string, options?: ParseOptions) {
       if (peg$silentFails === 0) { peg$fail(peg$c24); }
     }
     if (s2 as any !== peg$FAILED) {
-      s3 = peg$parsedigit();
+      if (input.substr(peg$currPos, 2) === peg$c25) {
+        s3 = peg$c25;
+        peg$currPos += 2;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      }
       if (s3 as any === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c25) {
-          s3 = peg$c25;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c26); }
-        }
+        s3 = peg$parsedigit();
       }
       if (s3 as any === peg$FAILED) {
         s3 = null;
@@ -4575,8 +4577,8 @@ function peg$parse(input: string, options?: ParseOptions) {
                             if (peg$silentFails === 0) { peg$fail(peg$c179); }
                           }
                           if (s5 as any !== peg$FAILED) {
-                            if (peg$c180.test(input.charAt(peg$currPos))) {
-                              s6 = input.charAt(peg$currPos);
+                            if (input.charCodeAt(peg$currPos) === 48) {
+                              s6 = peg$c180;
                               peg$currPos++;
                             } else {
                               s6 = peg$FAILED;
@@ -4599,24 +4601,36 @@ function peg$parse(input: string, options?: ParseOptions) {
                         }
                         if (s3 as any === peg$FAILED) {
                           s3 = peg$currPos;
-                          if (peg$c180.test(input.charAt(peg$currPos))) {
-                            s4 = input.charAt(peg$currPos);
+                          if (input.charCodeAt(peg$currPos) === 49) {
+                            s4 = peg$c176;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c181); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c177); }
                           }
                           if (s4 as any !== peg$FAILED) {
-                            if (peg$c182.test(input.charAt(peg$currPos))) {
+                            if (peg$c178.test(input.charAt(peg$currPos))) {
                               s5 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c183); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c179); }
                             }
                             if (s5 as any !== peg$FAILED) {
-                              s4 = [s4, s5];
-                              s3 = s4;
+                              if (peg$c182.test(input.charAt(peg$currPos))) {
+                                s6 = input.charAt(peg$currPos);
+                                peg$currPos++;
+                              } else {
+                                s6 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c183); }
+                              }
+                              if (s6 as any !== peg$FAILED) {
+                                s4 = [s4, s5, s6];
+                                s3 = s4;
+                              } else {
+                                peg$currPos = s3;
+                                s3 = peg$FAILED;
+                              }
                             } else {
                               peg$currPos = s3;
                               s3 = peg$FAILED;
@@ -4626,12 +4640,41 @@ function peg$parse(input: string, options?: ParseOptions) {
                             s3 = peg$FAILED;
                           }
                           if (s3 as any === peg$FAILED) {
+                            s3 = peg$currPos;
                             if (peg$c182.test(input.charAt(peg$currPos))) {
-                              s3 = input.charAt(peg$currPos);
+                              s4 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
-                              s3 = peg$FAILED;
+                              s4 = peg$FAILED;
                               if (peg$silentFails === 0) { peg$fail(peg$c183); }
+                            }
+                            if (s4 as any !== peg$FAILED) {
+                              if (peg$c184.test(input.charAt(peg$currPos))) {
+                                s5 = input.charAt(peg$currPos);
+                                peg$currPos++;
+                              } else {
+                                s5 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c185); }
+                              }
+                              if (s5 as any !== peg$FAILED) {
+                                s4 = [s4, s5];
+                                s3 = s4;
+                              } else {
+                                peg$currPos = s3;
+                                s3 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s3;
+                              s3 = peg$FAILED;
+                            }
+                            if (s3 as any === peg$FAILED) {
+                              if (peg$c184.test(input.charAt(peg$currPos))) {
+                                s3 = input.charAt(peg$currPos);
+                                peg$currPos++;
+                              } else {
+                                s3 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c185); }
+                              }
                             }
                           }
                         }
@@ -4682,12 +4725,12 @@ function peg$parse(input: string, options?: ParseOptions) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     s2 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c184) {
-      s3 = peg$c184;
+    if (input.substr(peg$currPos, 2) === peg$c186) {
+      s3 = peg$c186;
       peg$currPos += 2;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s3 as any !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 80) {
@@ -4699,11 +4742,11 @@ function peg$parse(input: string, options?: ParseOptions) {
       }
       if (s4 as any === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 83) {
-          s4 = peg$c186;
+          s4 = peg$c188;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c189); }
         }
         if (s4 as any === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 76) {
@@ -4714,12 +4757,12 @@ function peg$parse(input: string, options?: ParseOptions) {
             if (peg$silentFails === 0) { peg$fail(peg$c128); }
           }
           if (s4 as any === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c188) {
-              s4 = peg$c188;
+            if (input.substr(peg$currPos, 3) === peg$c190) {
+              s4 = peg$c190;
               peg$currPos += 3;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c189); }
+              if (peg$silentFails === 0) { peg$fail(peg$c191); }
             }
           }
         }
@@ -4776,7 +4819,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     s1 = peg$parsevar_dec_name();
     if (s1 as any !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c190();
+      s1 = peg$c192();
     }
     s0 = s1;
 
@@ -4827,7 +4870,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c193); }
     }
 
     return s0;
@@ -4882,7 +4925,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
 
     return s0;
@@ -4928,7 +4971,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c195); }
     }
 
     return s0;
@@ -4945,7 +4988,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
 
     return s0;
@@ -4962,7 +5005,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
 
     return s0;
@@ -4974,30 +5017,30 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c197;
+      s1 = peg$c199;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
     if (s1 as any !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = [];
-      if (peg$c199.test(input.charAt(peg$currPos))) {
+      if (peg$c201.test(input.charAt(peg$currPos))) {
         s4 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c200); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       while (s4 as any !== peg$FAILED) {
         s3.push(s4);
-        if (peg$c199.test(input.charAt(peg$currPos))) {
+        if (peg$c201.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
       }
       if (s3 as any !== peg$FAILED) {
@@ -5007,18 +5050,18 @@ function peg$parse(input: string, options?: ParseOptions) {
       }
       if (s2 as any !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 41) {
-          s3 = peg$c201;
+          s3 = peg$c203;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c202); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s3 as any === peg$FAILED) {
           s3 = null;
         }
         if (s3 as any !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c203(s2);
+          s1 = peg$c205(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5035,7 +5078,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
 
     return s0;
@@ -5047,30 +5090,30 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 59) {
-      s1 = peg$c205;
+      s1 = peg$c207;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 as any !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = [];
-      if (peg$c207.test(input.charAt(peg$currPos))) {
+      if (peg$c209.test(input.charAt(peg$currPos))) {
         s4 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c208); }
+        if (peg$silentFails === 0) { peg$fail(peg$c210); }
       }
       while (s4 as any !== peg$FAILED) {
         s3.push(s4);
-        if (peg$c207.test(input.charAt(peg$currPos))) {
+        if (peg$c209.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
       }
       if (s3 as any !== peg$FAILED) {
@@ -5080,7 +5123,7 @@ function peg$parse(input: string, options?: ParseOptions) {
       }
       if (s2 as any !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c203(s2);
+        s1 = peg$c205(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5093,7 +5136,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c204); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
 
     return s0;
@@ -5107,7 +5150,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+      if (peg$silentFails === 0) { peg$fail(peg$c211); }
     }
 
     return s0;
@@ -5117,17 +5160,17 @@ function peg$parse(input: string, options?: ParseOptions) {
     let s0, s1;
 
     peg$silentFails++;
-    if (peg$c211.test(input.charAt(peg$currPos))) {
+    if (peg$c213.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+      if (peg$silentFails === 0) { peg$fail(peg$c212); }
     }
 
     return s0;
@@ -5146,13 +5189,13 @@ function peg$parse(input: string, options?: ParseOptions) {
     }
     if (s1 as any !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c214();
+      s1 = peg$c216();
     }
     s0 = s1;
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c213); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
 
     return s0;
@@ -5162,12 +5205,12 @@ function peg$parse(input: string, options?: ParseOptions) {
     let s0, s1;
 
     peg$silentFails++;
-    if (input.substr(peg$currPos, 2) === peg$c216) {
-      s0 = peg$c216;
+    if (input.substr(peg$currPos, 2) === peg$c218) {
+      s0 = peg$c218;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c217); }
+      if (peg$silentFails === 0) { peg$fail(peg$c219); }
     }
     if (s0 as any === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 13) {
@@ -5190,7 +5233,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
 
     return s0;
@@ -5200,17 +5243,17 @@ function peg$parse(input: string, options?: ParseOptions) {
     let s0, s1;
 
     peg$silentFails++;
-    if (peg$c219.test(input.charAt(peg$currPos))) {
+    if (peg$c221.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c218); }
+      if (peg$silentFails === 0) { peg$fail(peg$c220); }
     }
 
     return s0;
@@ -5222,11 +5265,11 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c222;
+      s1 = peg$c224;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s1 as any === peg$FAILED) {
       s1 = null;
@@ -5247,7 +5290,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c221); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
 
     return s0;
@@ -5276,7 +5319,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c224); }
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
     }
 
     return s0;
@@ -5315,7 +5358,7 @@ function peg$parse(input: string, options?: ParseOptions) {
       }
       if (s2 as any !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c214();
+        s1 = peg$c216();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5328,7 +5371,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
     }
 
     return s0;
@@ -5340,22 +5383,22 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c227.test(input.charAt(peg$currPos))) {
+    if (peg$c229.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c228); }
+      if (peg$silentFails === 0) { peg$fail(peg$c230); }
     }
     if (s2 as any !== peg$FAILED) {
       while (s2 as any !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c227.test(input.charAt(peg$currPos))) {
+        if (peg$c229.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c230); }
         }
       }
     } else {
@@ -5369,7 +5412,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c228); }
     }
 
     return s0;
@@ -5380,12 +5423,12 @@ function peg$parse(input: string, options?: ParseOptions) {
 
     peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c182.test(input.charAt(peg$currPos))) {
+    if (peg$c184.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s1 as any !== peg$FAILED) {
       s0 = input.substring(s0, peg$currPos);
@@ -5395,7 +5438,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
 
     return s0;
@@ -5405,17 +5448,17 @@ function peg$parse(input: string, options?: ParseOptions) {
     let s0, s1;
 
     peg$silentFails++;
-    if (peg$c231.test(input.charAt(peg$currPos))) {
+    if (peg$c233.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
 
     return s0;
@@ -5435,21 +5478,21 @@ function peg$parse(input: string, options?: ParseOptions) {
     }
     if (s1 as any !== peg$FAILED) {
       s2 = [];
-      if (peg$c234.test(input.charAt(peg$currPos))) {
+      if (peg$c236.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c237); }
       }
       while (s3 as any !== peg$FAILED) {
         s2.push(s3);
-        if (peg$c234.test(input.charAt(peg$currPos))) {
+        if (peg$c236.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c235); }
+          if (peg$silentFails === 0) { peg$fail(peg$c237); }
         }
       }
       if (s2 as any !== peg$FAILED) {
@@ -5462,7 +5505,7 @@ function peg$parse(input: string, options?: ParseOptions) {
         }
         if (s3 as any !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c214();
+          s1 = peg$c216();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5479,7 +5522,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
 
     return s0;
@@ -5490,12 +5533,12 @@ function peg$parse(input: string, options?: ParseOptions) {
 
     peg$silentFails++;
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c237) {
-      s1 = peg$c237;
+    if (input.substr(peg$currPos, 8) === peg$c239) {
+      s1 = peg$c239;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 as any !== peg$FAILED) {
       s2 = [];
@@ -5509,12 +5552,12 @@ function peg$parse(input: string, options?: ParseOptions) {
         s2 = peg$FAILED;
       }
       if (s2 as any !== peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c239) {
-          s3 = peg$c239;
+        if (input.substr(peg$currPos, 5) === peg$c241) {
+          s3 = peg$c241;
           peg$currPos += 5;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c242); }
         }
         if (s3 as any !== peg$FAILED) {
           s4 = [];
@@ -5529,7 +5572,7 @@ function peg$parse(input: string, options?: ParseOptions) {
               s6 = peg$parsecomment_end();
               if (s6 as any !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c241(s5);
+                s1 = peg$c243(s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5558,7 +5601,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
 
     return s0;
@@ -5729,7 +5772,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
 
     return s0;
@@ -5752,7 +5795,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c245); }
     }
 
     return s0;
@@ -5869,11 +5912,11 @@ function peg$parse(input: string, options?: ParseOptions) {
             if (s5 as any !== peg$FAILED) {
               s6 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 45) {
-                s7 = peg$c222;
+                s7 = peg$c224;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c223); }
+                if (peg$silentFails === 0) { peg$fail(peg$c225); }
               }
               if (s7 as any !== peg$FAILED) {
                 s8 = [];
@@ -5980,7 +6023,7 @@ function peg$parse(input: string, options?: ParseOptions) {
                   }
                   if (s8 as any !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c245(s2, s4, s7);
+                    s1 = peg$c247(s2, s4, s7);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6017,7 +6060,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
 
     return s0;
@@ -6028,12 +6071,12 @@ function peg$parse(input: string, options?: ParseOptions) {
 
     peg$silentFails++;
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c237) {
-      s1 = peg$c237;
+    if (input.substr(peg$currPos, 8) === peg$c239) {
+      s1 = peg$c239;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 as any !== peg$FAILED) {
       s2 = [];
@@ -6047,12 +6090,12 @@ function peg$parse(input: string, options?: ParseOptions) {
         s2 = peg$FAILED;
       }
       if (s2 as any !== peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c247) {
-          s3 = peg$c247;
+        if (input.substr(peg$currPos, 3) === peg$c249) {
+          s3 = peg$c249;
           peg$currPos += 3;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s3 as any !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -6072,7 +6115,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
 
     return s0;
@@ -6129,7 +6172,7 @@ function peg$parse(input: string, options?: ParseOptions) {
     peg$silentFails--;
     if (s0 as any === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
 
     return s0;

--- a/server/src/parserSearching.ts
+++ b/server/src/parserSearching.ts
@@ -4,7 +4,7 @@ import { Match, Position, FileRange, IncrementableProgress, isMatch } from "./pa
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { normalizePath } from "./fileSystem";
 import { compareLocations as compareLocations } from "./stringSearching";
-import { ParseResults } from "./parsingResults";
+import { getParseResults } from "./parsingResults";
 import { MatchType } from "./matchTypes";
 
 /**
@@ -156,7 +156,7 @@ export function findMatchRangesWithinPrgTree(tree: any, types: MatchType[], name
  * @param progressHandler progress reporter
  * @returns the found ranges
  */
-export function findMatchRangesWithinPath(filePaths: string[], types: MatchType[], name: string, uriToOpenFileContent: Map<string, string>, progressHandler: IncrementableProgress): FileRange[] {
+export async function findMatchRangesWithinPath(filePaths: string[], types: MatchType[], name: string, uriToOpenFileContent: Map<string, string>, progressHandler: IncrementableProgress): Promise<FileRange[]> {
     let ranges: FileRange[] = [];
 
     // convert uri mapping of open files to normalized path mapping
@@ -173,11 +173,19 @@ export function findMatchRangesWithinPath(filePaths: string[], types: MatchType[
         }
         // report progress
         progressHandler.changeMessage(filePath);
-        // if file is open, get current file content of editor
+        // if file is open, get current file content of editor (an open but empty file is "", which is
+        // still the authoritative content, so only fall back to disk when the file is not open at all)
         let fileContent: string | undefined = pathToOpenFileContent.get(filePath);
-        // if file is not open, read file content from disk
-        if (!fileContent) {
-            fileContent = fs.readFileSync(filePath, 'utf8');
+        // if file is not open, read file content from disk (async so cancellation and other requests
+        // can be processed between files instead of blocking the whole server loop)
+        if (fileContent === undefined) {
+            try {
+                fileContent = await fs.promises.readFile(filePath, 'utf8');
+            } catch (error) {
+                console.error(`Error while reading ${filePath}: ${error}`);
+                progressHandler.increment();
+                continue;
+            }
         }
         // if file does not contain the searched match-name skip parsing/searching
         if (!fileContent.includes(name)) {
@@ -185,13 +193,13 @@ export function findMatchRangesWithinPath(filePaths: string[], types: MatchType[
             continue;
         }
         try {
-            const ast = new ParseResults(fileContent).results.fileTree;
+            const ast = getParseResults(fileContent).results.fileTree;
             const uri = pathToFileURL(filePath).toString();
             const fileRanges: FileRange[] = findMatchRangesWithinPrgTree(ast, types, name, uri);
             ranges.push(...fileRanges);
         } catch (error) {
-            const errorMessage = `Error while parsing ${filePath}: ${error} \nThis file is not included in the found references.`;
-            throw new Error(errorMessage);
+            // skip files that cannot be parsed instead of aborting the whole reference search
+            console.error(`Error while parsing ${filePath}: ${error} \nThis file is not included in the found references.`);
         }
 
         progressHandler.increment(filePath);

--- a/server/src/parsingResults.ts
+++ b/server/src/parsingResults.ts
@@ -129,6 +129,38 @@ export class ParseResults {
     }
 }
 
+/**
+ * Small content-keyed cache for parse results. The key is the exact document text, so a cache hit
+ * can never return stale data. This avoids re-parsing the same (unchanged) document across the
+ * completion/hover/definition/reference requests that typically follow each other.
+ */
+const parseCache = new Map<string, ParseResults>();
+const PARSE_CACHE_MAX = 16;
+
+/**
+ * Returns the {@link ParseResults} for the given text, reusing a cached result when the exact same
+ * text was parsed recently.
+ * @throws Error if the parser throws an error
+ */
+export function getParseResults(text: string): ParseResults {
+    const cached = parseCache.get(text);
+    if (cached) {
+        // refresh recency (Map keeps insertion order)
+        parseCache.delete(text);
+        parseCache.set(text, cached);
+        return cached;
+    }
+    const result = new ParseResults(text);
+    parseCache.set(text, result);
+    if (parseCache.size > PARSE_CACHE_MAX) {
+        const oldestKey = parseCache.keys().next().value;
+        if (oldestKey !== undefined) {
+            parseCache.delete(oldestKey);
+        }
+    }
+    return result;
+}
+
 export interface SyntaxArray {
     toolCalls: Array<Match>;
     prgCallNames: Array<Match>;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,7 +16,7 @@ import { Position } from './parserClasses';
 import * as config from './config';
 import { getCompletions, updateStaticCycleCompletions, updateStaticGeneralCompletions } from './completion';
 import { getHoverInformation } from './hover';
-import { ParseResults } from './parsingResults';
+import { getParseResults } from './parsingResults';
 // Create a connection for the server.
 // If --stdio flag is passed, use stdio transport; otherwise use IPC (default).
 // This allows the server to work both as a VS Code extension and as a remote LSP server over WebSocket.
@@ -105,7 +105,7 @@ connection.onDefinition((docPos) => {
 		}
 		const text = textDocument.getText();
 		const position: Position = docPos.position;
-		return parser.getDefinition(new ParseResults(text), position, docPos.textDocument.uri, getRootPaths(), getOpenDocs()).definitionRanges;
+		return parser.getDefinition(getParseResults(text), position, docPos.textDocument.uri, getRootPaths(), getOpenDocs()).definitionRanges;
 	} catch (error) {
 		connection.console.error("Getting definition failed: " + (error instanceof Error ? error.stack : String(error)));
 		connection.window.showErrorMessage("Getting definition failed: " + getErrorMessage(error));

--- a/server/src/stringSearching.ts
+++ b/server/src/stringSearching.ts
@@ -10,19 +10,21 @@ import { getCommandUriToOpenDocu } from "./helper";
  * @param uri the uri of the file
  * @returns an array of file ranges (uri and start/end positions)
  */
-export function findLocalStringRanges(fileContent: string, string: string, uri: string): FileRange[] {
+export function findLocalStringRanges(fileContent: string, string: string, uri: string, commentMatches?: Match[], wholeWord: boolean = false): FileRange[] {
     // if string is empty, return empty array
     if (string.length === 0) {
         return [];
     }
     let ranges: FileRange[] = [];
     const lines = fileContent.split("\n");
-    let commentMatches: Match[];
-    try {
-        commentMatches = new ParseResults(fileContent).syntaxArray.comments;
-    } catch (error) {
-        // if the parser fails, comments are not excluded
-        commentMatches = [];
+    // reuse comments from an already parsed tree if provided, otherwise parse once here
+    if (commentMatches === undefined) {
+        try {
+            commentMatches = new ParseResults(fileContent).syntaxArray.comments;
+        } catch (error) {
+            // if the parser fails, comments are not excluded
+            commentMatches = [];
+        }
     }
 
     for (let i = 0; i < lines.length; i++) {
@@ -30,7 +32,13 @@ export function findLocalStringRanges(fileContent: string, string: string, uri: 
         let varIndex = line.indexOf(string);
         while (varIndex !== -1) {
             const varEnd = varIndex + string.length;
-            if (!isWithinMatches(commentMatches, new Position(i, varIndex))) {
+            // For variable searches (wholeWord) the match must not be the prefix of a longer variable
+            // name (e.g. V.P.FOO must not match inside V.P.FOOBAR / V.P.FOO.BAR). Only the trailing
+            // boundary is checked: NC address words like the "X" in "XV.L.VAR" legitimately precede a
+            // variable, so a leading identifier character must not disqualify the match.
+            const after = varEnd < line.length ? line[varEnd] : "";
+            const trailingBoundaryOk = !wholeWord || !/[_a-zA-Z0-9.]/.test(after);
+            if (trailingBoundaryOk && !isWithinMatches(commentMatches, new Position(i, varIndex))) {
                 const range = new FileRange(uri, new Position(i, varIndex), new Position(i, varEnd));
                 ranges.push(range);
             }
@@ -64,28 +72,24 @@ export function isWithinMatches(matches: Match[], pos: Position): boolean {
  * @returns the surrounding variable string or null if no variable is found at the given position 
  */
 export function getSurroundingVar(text: string, position: Position): string | null {
-    let result = null;
     const lines = text.split("\n");
     const line = lines[position.line];
-    const varRegex = /^V\.(P|S|L|CYC)\.[_a-zA-Z0-9]+/gm;
+    if (line === undefined) {
+        return null;
+    }
+    // dots are part of the name (e.g. V.P.FOO.BAR), matching the grammar rule name = [_a-zA-Z0-9.]+
+    const varRegex = /V\.(P|S|L|CYC)\.[_a-zA-Z0-9.]+/g;
 
-    // word begin can be between 0 and position.character
-    for (let begin = 0; begin <= position.character; begin++) {
-        // get match which starts at current begin
-        const substring = line.substring(begin);
-        const match = substring.match(varRegex);
-        if (match) {
-            const matchString = match[0];
-            const matchEnd = begin + matchString.length;
-
-            // if match ends after position.character, we found the surrounding variable
-            if (matchEnd >= position.character) {
-                result = matchString;
-                break;
-            }
+    // scan the line once and return the variable that contains the position (single pass instead of O(col^2))
+    let match: RegExpExecArray | null;
+    while ((match = varRegex.exec(line)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        if (position.character >= start && position.character <= end) {
+            return match[0];
         }
     }
-    return result;
+    return null;
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,19 +62,27 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ language: 'isg-cnc' }],
-        markdown: { isTrusted: true },
+        // Only allow the extension's own documentation command in hover/completion markdown.
+        // Trusting all commands would let a prepared NC file execute arbitrary VS Code commands
+        // (e.g. terminal input) via a command:-link built from unescaped file comments.
+        markdown: { isTrusted: { enabledCommands: ['isg-cnc.openDocuWithId'] } },
     };
 
     // start the cnc language server
     try {
         client = new LanguageClient("cnc-client", serverOptions, clientOptions);
-        client.start();
+        client.start().catch((error) => {
+            console.error(error);
+            vscode.window.showErrorMessage("Failed to start the ISG-CNC language server. Language features are unavailable.");
+        });
     } catch (error) {
         console.error(error);
     }
 
     // code formatter
-    vscode.languages.registerDocumentRangeFormattingEditProvider('isg-cnc', new formatter.DocumentRangeFormattingEditProvider());
+    context.subscriptions.push(
+        vscode.languages.registerDocumentRangeFormattingEditProvider('isg-cnc', new formatter.DocumentRangeFormattingEditProvider())
+    );
 
     //NC-file sidebar tree provider
     fileContentProvider = new fileContentTree.FileContentProvider(extContext);
@@ -181,11 +189,10 @@ export function activate(context: vscode.ExtensionContext): void {
  * This method is called when the extension is deactivated
  *
  */
-export function deactivate(): void {
+export function deactivate(): Thenable<void> | undefined {
     printToOutputchannel("Deactivate vscode-isg-cnc extension");
     disposeOutputchannel();
-    if (client) {
-        client.stop();
-    }
+    // return the promise so VS Code waits for the language server to shut down cleanly
+    return client ? client.stop() : undefined;
 }
 

--- a/src/shared/languageServer.ts
+++ b/src/shared/languageServer.ts
@@ -1,0 +1,18 @@
+/**
+ * Single, explicit boundary between the extension client and the language server's code.
+ *
+ * The client reuses the real grammar parser (and a few file-system helpers) of the language server
+ * instead of duplicating them with fragile regex heuristics. Keeping every such import in this one
+ * module makes that coupling explicit and refactor-safe: if the server layout changes, or these
+ * features are eventually moved behind dedicated LSP requests, only this file needs to change
+ * instead of every feature module reaching into `../../server/src/*`.
+ *
+ * NOTE: importing {@link ParseResults} means the (large, generated) grammar parser runs synchronously
+ * in the extension host. Moving the formatter / outline / block-number features to server-side LSP
+ * requests would remove that in-process parsing entirely; that is a larger, separate change.
+ */
+export { ParseResults } from "../../server/src/parsingResults";
+export { MatchType } from "../../server/src/matchTypes";
+export { WorkspaceIgnorer, findFileInRootDir } from "../../server/src/fileSystem";
+export type { SyntaxArray } from "../../server/src/parsingResults";
+export type { Match } from "../../server/src/parserClasses";

--- a/src/test/suite/client/encryption.test.ts
+++ b/src/test/suite/client/encryption.test.ts
@@ -1,0 +1,45 @@
+import assert = require("assert");
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { encryptFileToFile } from "../../../util/encryption/blowfish";
+
+suite("Client encryption (Blowfish)", () => {
+    let dir: string;
+    setup(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), "isg-cnc-bf-"));
+    });
+    teardown(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("encrypts a block-aligned file deterministically (golden vector)", () => {
+        const inputPath = path.join(dir, "in.nc");
+        const outputPath = path.join(dir, "out.ecy");
+        // 16 bytes = multiple of 8 -> no random padding, fully deterministic
+        fs.writeFileSync(inputPath, "ABCDEFGH12345678");
+        encryptFileToFile(inputPath, outputPath, "testkey1");
+        const encrypted = fs.readFileSync(outputPath);
+        assert.strictEqual(encrypted.length, 16);
+        // golden value locks in the cipher bit-arithmetic against regressions
+        assert.strictEqual(encrypted.toString("hex"), "5df9cdf6e122cba58a37d3ed94ba41fe");
+    });
+
+    test("produces the same ciphertext for the same input and key", () => {
+        const inputPath = path.join(dir, "in.nc");
+        const out1 = path.join(dir, "out1.ecy");
+        const out2 = path.join(dir, "out2.ecy");
+        fs.writeFileSync(inputPath, "SOMEDATA"); // 8 bytes, block-aligned
+        encryptFileToFile(inputPath, out1, "key12345");
+        encryptFileToFile(inputPath, out2, "key12345");
+        assert.deepStrictEqual(fs.readFileSync(out1), fs.readFileSync(out2));
+    });
+
+    test("pads a non-block-aligned file up to the next multiple of 8", () => {
+        const inputPath = path.join(dir, "in.nc");
+        const outputPath = path.join(dir, "out.ecy");
+        fs.writeFileSync(inputPath, "12345"); // 5 bytes -> padded to 8
+        encryptFileToFile(inputPath, outputPath, "key12345");
+        assert.strictEqual(fs.readFileSync(outputPath).length, 8);
+    });
+});

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -15,7 +15,8 @@ export async function run(): Promise<void> {
     const tmpPath = getPathOfWorkspaceFile("tmp.nc");
     fs.writeFileSync(tmpPath, "");
     // open the test workspace and wait for the server to initialize
-    const ext = vscode.extensions.getExtension("vscode-isg-cnc");
+    // the extension id is "<publisher>.<name>" = "isg-cnc.vscode-isg-cnc"
+    const ext = vscode.extensions.getExtension("isg-cnc.vscode-isg-cnc");
     await ext?.activate();
     console.log("Extension activated");
     try {

--- a/src/util/aligning.ts
+++ b/src/util/aligning.ts
@@ -1,5 +1,4 @@
-import { Match } from '../../server/src/parserClasses';
-import { ParseResults } from '../../server/src/parsingResults';
+import { Match, ParseResults } from '../shared/languageServer';
 import * as vscode from 'vscode';
 
 /**
@@ -67,12 +66,17 @@ export async function alignEqualSigns(): Promise<void> {
         const selection: vscode.Selection = editor.selection;
         if (!selection.isEmpty) {
             const lines: Array<EqSignLine> = new Array();
-            // collect all selected lines with "="
+            // collect all selected lines with a real assignment "="
             for (let ln = selection.start.line; ln <= selection.end.line; ln++) {
                 //get intersection of selection and current line to only handle selected part when in first or last line
                 const range = selection.intersection(editor.document.lineAt(ln).range);
-                if (range && editor.document.getText(range).includes("=")) {
-                    lines.push(new EqSignLine(editor.document.getText(range), range));
+                if (range) {
+                    const text = editor.document.getText(range);
+                    // only align a real assignment "=", never a comparison operator (==, <=, >=, !=)
+                    const eqIndex = findAssignmentEqualIndex(text);
+                    if (eqIndex !== -1) {
+                        lines.push(new EqSignLine(text, range, eqIndex));
+                    }
                 }
             }
 
@@ -90,14 +94,22 @@ export async function alignEqualSigns(): Promise<void> {
 }
 
 /**
+ * Returns the index of the first real assignment "=" in the line, i.e. an "=" that is not part of
+ * a comparison operator ("==", "<=", ">=", "!="). Returns -1 if there is no such assignment.
+ */
+function findAssignmentEqualIndex(line: string): number {
+    const match = /(?<![=<>!])=(?!=)/.exec(line);
+    return match ? match.index : -1;
+}
+
+/**
  * Helper class to save the information about the equal sign lines.
  */
 class EqSignLine {
     beforeEq: string;
     afterEq: string;
     range: vscode.Range;
-    constructor(line: string, range: vscode.Range) {
-        const eqIndex = line.indexOf("=");
+    constructor(line: string, range: vscode.Range, eqIndex: number) {
         this.beforeEq = line.substring(0, eqIndex).trimEnd();
         this.afterEq = line.substring(eqIndex + 1).trimStart();
         this.range = range;

--- a/src/util/blockNumbers.ts
+++ b/src/util/blockNumbers.ts
@@ -1,12 +1,8 @@
 import * as vscode from "vscode";
 import { digitCount, isNumeric } from "./util";
-import { ParseResults } from "../../server/src/parsingResults";
-import { Match } from "../../server/src/parserClasses";
-import { MatchType } from "../../server/src/matchTypes";
+import { ParseResults, Match, MatchType } from "../shared/languageServer";
 import { getIncludeCommentsInNumbering } from "./config";
-
-// Blocknumber regex
-const regExpLabels = new RegExp(/(\s?)N[0-9]*:{1}(\s?)|\[.*\]:{1}/);
+import { regExpLabels } from "./ncBlockRegex";
 
 /**
  * Remove all block numbers
@@ -34,9 +30,15 @@ export async function removeAllBlocknumbers() {
                 const blockNumber: Match | undefined = linesToBlocknumberMap.get(ln);
                 if (blockNumber !== undefined) {
                     let gotoPos = line.text.indexOf("$GOTO");
+                    // peggy locations are 1-based and end.column points *after* the last matched
+                    // character, so the 0-based exclusive end of the block number is end.column - 1
+                    const blockNumberEnd = blockNumber.location.end.column - 1;
+                    // remove a single trailing separating space if present, but never the following
+                    // command (e.g. keep the "G" in compact "N10G01")
+                    const deleteEnd = line.text.charAt(blockNumberEnd) === " " ? blockNumberEnd + 1 : blockNumberEnd;
                     const range = new vscode.Range(
                         new vscode.Position(ln, blockNumber.location.start.column - 1),
-                        new vscode.Position(line.lineNumber, blockNumber.location.end.column)
+                        new vscode.Position(line.lineNumber, deleteEnd)
                     );
                     // if label found and blocknumber are the same -> skip deleting
                     if (matchLabel !== null && ((gotoPos === -1) || (line.text.indexOf(matchLabel[0]) < gotoPos)) && line.text.indexOf(matchLabel[0].trim()) === blockNumber.location.start.column - 1) {
@@ -54,14 +56,22 @@ export async function removeAllBlocknumbers() {
             if (getIncludeCommentsInNumbering()) {
                 textEdits.length = 0;
                 parseResults.syntaxArray.comments.forEach((match) => {
-                    // check for all comment lines if the trimmed version BEGINS with a N[0-9]*
+                    // check for all comment lines if they begin (ignoring leading whitespace) with a block number
                     for (let i = match.location.start.line - 1; i <= match.location.end.line - 1; i++) {
                         const line = document.lineAt(i);
-                        const blockNumberMatch = new RegExp(/^\s*N[0-9]*/).exec(line.text.trim());
+                        // match on the untrimmed line so index/length line up with the real range;
+                        // require at least one digit so plain words like "Note" are not touched
+                        const blockNumberMatch = /^(\s*)(N[0-9]+)/.exec(line.text);
                         if (blockNumberMatch !== null) {
+                            const start = blockNumberMatch[1].length;
+                            let end = start + blockNumberMatch[2].length;
+                            // remove a single trailing separating space if present
+                            if (line.text.charAt(end) === " ") {
+                                end += 1;
+                            }
                             const range = new vscode.Range(
-                                new vscode.Position(i, blockNumberMatch.index),
-                                new vscode.Position(i, blockNumberMatch.index + blockNumberMatch[0].length + 1)
+                                new vscode.Position(i, start),
+                                new vscode.Position(i, end)
                             );
                             textEdits.push(vscode.TextEdit.replace(range, ""));
                         }
@@ -146,20 +156,22 @@ export async function addBlockNumbers(start: number, step: number) {
             const parseResult: ParseResults = new ParseResults(document.getText());
             const linesToNumber: Array<number> = parseResult.getNumberableLines();
             const includeComments = getIncludeCommentsInNumbering();
-            const commentLines: Array<number> = [];
+            const commentLines: Set<number> = new Set();
             // if configuration says to also number comments, add them to linesToNumber
             if (includeComments) {
+                const numberedLines: Set<number> = new Set(linesToNumber);
                 parseResult.syntaxArray.comments.forEach((match) => {
-                    // push all lines between match.location.start.line and match.location.end.line to linesToNumber if not already included
+                    // add all lines of the comment to linesToNumber if not already included
                     for (let i = match.location.start.line - 1; i <= match.location.end.line - 1; i++) {
-                        if (!linesToNumber.includes(i)) {
+                        if (!numberedLines.has(i)) {
+                            numberedLines.add(i);
                             linesToNumber.push(i);
-                            commentLines.push(i);
+                            commentLines.add(i);
                         }
                     }
-                    // sort because now the order may be destroyed
-                    linesToNumber.sort((a: number, b: number) => a - b);
                 });
+                // sort once after collecting instead of on every comment match
+                linesToNumber.sort((a: number, b: number) => a - b);
             }
             const skipLineBeginIndexes: Map<number, number> = new Map();
             let skipBlocks;
@@ -181,7 +193,10 @@ export async function addBlockNumbers(start: number, step: number) {
                 return;
             }
             // add new blocknumbers
-            const maxDigits = digitCount(start + linesToNumber.length * step);
+            // the highest assigned block number is start + (numberedCount - 1) * step, and empty
+            // lines are skipped without consuming a number, so count only non-empty lines
+            const numberedCount = linesToNumber.filter(ln => document.lineAt(ln).text.trim() !== "").length;
+            const maxDigits = digitCount(start + Math.max(0, numberedCount - 1) * step);
 
             for (let ln of linesToNumber) {
                 const line = document.lineAt(ln);
@@ -220,7 +235,7 @@ export async function addBlockNumbers(start: number, step: number) {
                     } else {
                         textEdits.push(vscode.TextEdit.replace(range, blockNumberString));
                     }
-                } else if (includeComments && commentLines.includes(ln)) {
+                } else if (includeComments && commentLines.has(ln)) {
                     // if parser did not give blocknumber but comments are included and this is a comment line which starts with blocknumber regex, replace it
                     const blockNumberMatch = line.text.match(/^\s*N[0-9]*/);
                     if (blockNumberMatch?.index !== undefined) {
@@ -239,7 +254,10 @@ export async function addBlockNumbers(start: number, step: number) {
                     let insertIndex: number;
                     const skipLineBegin: number | undefined = skipLineBeginIndexes.get(line.lineNumber + 1);  //parser is 1 based
                     if (skipLineBegin !== undefined) {
-                        insertIndex = skipLineBegin;
+                        // insert *after* the complete skip marker ("/", "/0".."/9" or "/10"),
+                        // otherwise a multi-character marker would be split (e.g. "/1" -> "/N10 1")
+                        const markerMatch = /^\s*\/(?:10|[0-9])?/.exec(line.text);
+                        insertIndex = markerMatch ? markerMatch[0].length : skipLineBegin;
                     } else {
                         insertIndex = line.range.start.character;
                     }

--- a/src/util/documentation.ts
+++ b/src/util/documentation.ts
@@ -19,6 +19,11 @@ export function openDocu(): void {
  * @param id the id of the documentation to open
  */
 export function openDocuWithId(id: string): void {
+    // reject ids that could escape the documentation directory (path traversal via "/", "\" or "..")
+    if (!/^[\w.-]+$/.test(id) || id.includes("..")) {
+        vscode.window.showWarningMessage(`Invalid documentation id: ${id}`);
+        return;
+    }
     // if the documentation does not start with http, interpret it as local file path and open it in browser
     if (!getDocumentationPath().startsWith("http")) {
         const filePath = path.join(getDocumentationPath(), getLocale(), `${id}.html`);
@@ -48,23 +53,8 @@ export function createFullAddress(): string {
         } else {
             localeDocuPath += `${locale}/`;
         }
-        //IMPORTANT: THE FOLLOWING BLOCK IS FOR OPEN DOCU WITH SELECTED SEARCHING KEYWORD
-        //THE WEBSITE IS BROKEN AT THE MOMENT SO IT WILL JUST LOAD THE GENERAL DOCU WEBSITE
-        //UNCOMMENT IF THE WEBSITE WAS FIXES AND DELETE THE ASSIGNMENT UNDER THE COMMENT:
-        //  "docuAddress = localeDocuPath + "index.html";"
-        /*  if (!activeTextEditor.selection.isEmpty) {
-             searchContext = activeTextEditor.document.getText(
-                 activeTextEditor.selection
-             );
-             const query = new URLSearchParams();
-             query.append("q", searchContext);
-             docuAddress = localeDocuPath + `search.html?${query.toString()}`;
-         } else {
-              docuAddress = localeDocuPath + "index.html";
-         } */
         docuAddress = localeDocuPath + "index.html";
     }
-    printToOutputchannel(docuAddress);
     printToOutputchannel(`Address to the website: ${docuAddress}`);
     return docuAddress;
 }

--- a/src/util/encryption/blowfish.ts
+++ b/src/util/encryption/blowfish.ts
@@ -109,19 +109,11 @@ const S_BOXES_CONST = [
   ]),
 ];
 /**
- * Generates a random byte.
+ * Generates a cryptographically secure random byte.
  * @returns random byte (number between 0 and 255)
  */
 function getRandomByte(): number {
-  let hash: crypto.Hash = crypto.createHash('sha1');
-  const date: number = Date.now();
-  hash.update(date.toString());
-  let randomHex: string = hash.digest('hex');
-  if (randomHex.length > 2) {
-    const randomInt = Math.floor(Math.random() * (randomHex.length - 2));
-    randomHex = randomHex.substring(randomInt, randomInt + 2);
-  }
-  return parseInt(randomHex, 16);
+  return crypto.randomBytes(1)[0];
 }
 
 /**

--- a/src/util/fileContentTree.ts
+++ b/src/util/fileContentTree.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as Path from "path";
-import * as parser from "../../server/src/parsingResults";
-
-import { Match } from '../../server/src/parserClasses';
+import { ParseResults, SyntaxArray, Match } from "../shared/languageServer";
 
 export enum Sorting {
     lineByLine,
     grouped
 }
+
+/** Maximum number of matches shown per category before a "more matches" hint is added. */
+const MAX_SHOWN_MATCHES = 500;
 
 /**
  * The Tree Data Provider for the NC-Match-Tree
@@ -20,6 +21,7 @@ export class FileContentProvider implements vscode.TreeDataProvider<vscode.TreeI
     matchCategories: MatchCategories;
     context: vscode.ExtensionContext;
     currentFileWatcher: fs.FSWatcher | undefined;
+    private watchDebounce: ReturnType<typeof setTimeout> | undefined;
     file: vscode.Uri | undefined;
 
     sorting: Sorting = Sorting.lineByLine;
@@ -47,15 +49,23 @@ export class FileContentProvider implements vscode.TreeDataProvider<vscode.TreeI
         } else if (!ncFileOpened()) {
             this.fileItem = new FileItem("The currently opened file is no NC-file", vscode.TreeItemCollapsibleState.None);
         } else {
-            const fileContent = fs.readFileSync(this.file.fsPath, "utf-8");
-            let syntaxArray: parser.SyntaxArray;
+            let fileContent: string;
             try {
-                syntaxArray = new parser.ParseResults(fileContent).syntaxArray;
+                fileContent = fs.readFileSync(this.file.fsPath, "utf-8");
+            } catch (error) {
+                this.fileItem = new FileItem("Error while reading file: " + getErrorMessage(error), vscode.TreeItemCollapsibleState.None);
+                return;
+            }
+            let syntaxArray: SyntaxArray;
+            try {
+                syntaxArray = new ParseResults(fileContent).syntaxArray;
             } catch (error) {
                 this.fileItem = new FileItem("Error while parsing: " + error, vscode.TreeItemCollapsibleState.None);
                 return;
             }
-            this.updateMatchItems(syntaxArray);
+            // split the file once (EOL-agnostic) and reuse the line array for every match label
+            const lines = fileContent.split(/\r?\n/);
+            this.updateMatchItems(syntaxArray, lines);
             this.fileItem = new FileItem(Path.basename(this.file.fsPath), vscode.TreeItemCollapsibleState.Expanded, this.matchCategories);
         }
     }
@@ -64,7 +74,11 @@ export class FileContentProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (this.file !== undefined) {
             this.currentFileWatcher?.close();
             this.currentFileWatcher = fs.watch(this.file.fsPath, () => {
-                this.update();
+                // fs.watch can fire several times per save; debounce to a single refresh
+                if (this.watchDebounce) {
+                    clearTimeout(this.watchDebounce);
+                }
+                this.watchDebounce = setTimeout(() => this.update(), 200);
             });
         }
     }
@@ -74,24 +88,23 @@ export class FileContentProvider implements vscode.TreeDataProvider<vscode.TreeI
      */
     async update(): Promise<void> {
         try {
-            this.file = vscode.window.activeTextEditor?.document.uri;;
-            this.updateFileTree();
+            this.file = vscode.window.activeTextEditor?.document.uri;
+            await this.updateFileTree();
             this.updateFileWatcher();
         } catch (error: any) {
-            vscode.window.showErrorMessage(error);
+            this.fileItem = new FileItem("Error: " + getErrorMessage(error), vscode.TreeItemCollapsibleState.None);
         }
         this._onDidChangeTreeData.fire();  //triggers updating the graphic
     }
 
     /**
      * Update match tree-items
-     * @param syntaxArray 
+     * @param syntaxArray
+     * @param lines the lines of the current file, reused for all match labels
      */
-    async updateMatchItems(syntaxArray: parser.SyntaxArray): Promise<void> {
-        await Promise.all([
-            new Promise(() => this.matchCategories.toolCalls.resetMatches(syntaxArray.toolCalls, this.sorting)),
-            new Promise(() => this.matchCategories.prgCallNames.resetMatches(syntaxArray.prgCallNames, this.sorting))
-        ]);
+    updateMatchItems(syntaxArray: SyntaxArray, lines: string[]): void {
+        this.matchCategories.toolCalls.resetMatches(syntaxArray.toolCalls, this.sorting, lines);
+        this.matchCategories.prgCallNames.resetMatches(syntaxArray.prgCallNames, this.sorting, lines);
     }
 
 
@@ -185,19 +198,19 @@ class CategoryItem extends vscode.TreeItem implements MyItem {
      * Overwrites old children with new ones
      * @param newMatches 
      */
-    resetMatches(newMatches: Match[], sorting: Sorting) {
+    resetMatches(newMatches: Match[], sorting: Sorting, lines: string[]) {
 
         /**
          * Inner function to add a match to its match-line or create a new one if non-existing
-         * @param match 
-         * @param matchMap 
-         * @param itemPosition 
+         * @param match
+         * @param matchMap
+         * @param itemPosition
          */
         function addMatchToMatchLine(match: Match, matchMap: Map<number, MatchItem>, itemPosition: ItemPosition) {
             // create item for the match-line if it doesn't already exist
             let matchLineItem: MatchItem | undefined = matchMap.get(match.location.start.line);
             if (matchLineItem === undefined) {
-                matchMap.set(match.location.start.line, new MatchItem(match, itemPosition));
+                matchMap.set(match.location.start.line, new MatchItem(match, itemPosition, lines));
             }
             //or additionally highlight new match if line already exists
             else {
@@ -206,43 +219,25 @@ class CategoryItem extends vscode.TreeItem implements MyItem {
         }
 
         this.clearChildren();
-        let matchCounter = 0;
-        try {
-            newMatches.forEach(match => {
-                matchCounter++;
-                if (matchCounter > 500) {
-                    const tooManyMatchesException = {};
-                    throw tooManyMatchesException;
+        // only show the first MAX_SHOWN_MATCHES matches for performance
+        const shownCount = Math.min(newMatches.length, MAX_SHOWN_MATCHES);
+        for (let i = 0; i < shownCount; i++) {
+            const match = newMatches[i];
+            if (sorting === Sorting.lineByLine) {
+                addMatchToMatchLine(match, this.children.matchMap, ItemPosition.category);
+            } else if (sorting === Sorting.grouped) {
+                // e.g. toolCalls will be seperated in subCategories T1, T2 etc.
+                let subCategory: SubCategoryTreeItem | undefined = this.children.matchSubCategoryMap.get(match.text);
+                //create subCategory when non-existing
+                if (subCategory === undefined) {
+                    subCategory = new SubCategoryTreeItem(match.text);
+                    this.children.matchSubCategoryMap.set(match.text, subCategory);
                 }
-                let matchToHiglight: Match;
-                matchToHiglight = match;
-                if (sorting === Sorting.lineByLine) {
-                    addMatchToMatchLine(matchToHiglight, this.children.matchMap, ItemPosition.category);
-                } else if (sorting === Sorting.grouped) {
-                    // e.g. toolCalls will be seperated in subCategories T1, T2 etc.
-                    let subCategory: SubCategoryTreeItem | undefined = this.children.matchSubCategoryMap.get(matchToHiglight.text);
-
-                    //create subCategory when non-existing
-                    if (subCategory === undefined) {
-                        this.children.matchSubCategoryMap.set(matchToHiglight.text, new SubCategoryTreeItem(matchToHiglight.text));
-                    }
-
-                    subCategory = this.children.matchSubCategoryMap.get(matchToHiglight.text);
-                    //make sure subCategory exists now and add match to it
-                    if (subCategory !== undefined) {
-                        addMatchToMatchLine(matchToHiglight, subCategory.children, ItemPosition.subCategory);
-                    } else {
-                        throw new Error("subCategory " + matchToHiglight.text + " was not created successfully");
-                    }
-                }
-            });
-        } catch (error) {
-            if (matchCounter > 500) {
-                let messageItem: MessageItem = new MessageItem("There are " + (newMatches.length - 500) + " more matches, which aren't shown due to performance");
-                this.children.messages.push(messageItem);
-            } else {
-                console.error(error);
+                addMatchToMatchLine(match, subCategory.children, ItemPosition.subCategory);
             }
+        }
+        if (newMatches.length > MAX_SHOWN_MATCHES) {
+            this.children.messages.push(new MessageItem("There are " + (newMatches.length - MAX_SHOWN_MATCHES) + " more matches, which aren't shown due to performance"));
         }
     }
 }
@@ -276,9 +271,10 @@ export class MatchItem extends vscode.TreeItem implements MyItem {
     match: Match;
     matchLineLabel: MatchLineLabel;
 
-    constructor(match: Match, itemPos: ItemPosition) {
-        super(new MatchLineLabel(match).label);
-        this.matchLineLabel = new MatchLineLabel(match);
+    constructor(match: Match, itemPos: ItemPosition, lines: string[]) {
+        const matchLineLabel = new MatchLineLabel(match, lines);
+        super(matchLineLabel.label);
+        this.matchLineLabel = matchLineLabel;
         this.match = match;
         const commandID: string = match.name + "_" + match.location.start.offset.toString() + "_" + itemPos;
         this.command = {
@@ -310,26 +306,22 @@ export class MatchItem extends vscode.TreeItem implements MyItem {
  * Class for a match-line-label
  */
 export class MatchLineLabel {
-    private _file;
     private _label: { label: string; highlights: [number, number][]; };
     public get label(): { label: string; highlights: [number, number][]; } {
         return this._label;
     }
 
     private _textoffset: number;
-    constructor(match: Match) {
-        const document = vscode.window.activeTextEditor?.document;
-        this._file = document?.uri.fsPath;
+    constructor(match: Match, lines: string[]) {
         let labelString: string;
         let textoffset: number;
 
-        if (this._file !== undefined && document !== undefined) {
-            const eol = document.eol;
-            const paddingGoal = getMaxLine(this._file, eol).toString().length;
+        if (lines.length > 0) {
+            const paddingGoal = lines.length.toString().length;
             const lineNumber = match.location.start.line;
             const column = match.location.start.column;
             labelString = lineNumber.toString().padStart(paddingGoal, '0') + ": ";
-            let text: string = getLine(this._file, match.location.start.line, eol);
+            let text: string = lines[lineNumber - 1] ?? "";
             textoffset = paddingGoal + 2/* skip ': ' */ - 1 /*different counting between match and label*/;
 
             //label shall contain a maximum of 15 characters left from the match
@@ -404,29 +396,10 @@ class MessageItem extends vscode.TreeItem implements MyItem {
 
 //#region Helper functions
 /**
- * Updates the maxLine-Variable of this module indicating the max amount of lines in the current file
- * @param file 
+ * Returns a readable message for an unknown error value.
  */
-function getMaxLine(file: string, eol: vscode.EndOfLine): number {
-    const newline = eol === vscode.EndOfLine.LF ? "\n" : "\r\n";
-    const filecontent: string = fs.readFileSync(file, "utf8");
-    const lineArray = filecontent.split(newline);
-    return lineArray.length;
-}
-
-/**
- * Returns the the specified line of a file, empty String when not found
- * @param file 
- * @param lineNumber 1-based
- * @returns the line as a string
- */
-function getLine(file: string, lineNumber: number, eol: vscode.EndOfLine): string {
-    let result = "";
-    const filecontent: string | undefined = fs.readFileSync(file, "utf8");
-    const newline = eol === vscode.EndOfLine.LF ? "\n" : "\r\n";
-    const lineArray = filecontent.split(newline);
-    result = lineArray[lineNumber - 1];
-    return result;
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
 }
 
 /**

--- a/src/util/fileoffset.ts
+++ b/src/util/fileoffset.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { isNumeric } from './util';
 import { updateCurrentOffsetStatusBarItem } from './statusbar';
-import { WorkspaceIgnorer, findFileInRootDir } from '../../server/src/fileSystem';
+import { WorkspaceIgnorer, findFileInRootDir } from '../shared/languageServer';
 import * as path from 'path';
 
 /**
@@ -29,14 +29,17 @@ export async function jumpIntoFileAtOffset() {
         return vscode.window.showErrorMessage("No fitting file found.");
     }
 
-    // get offset if valid second selection is found
-    const offsetText = document.getText(selections[1]).trim();
+    // get offset if a valid second selection is found (guard the index: getText(undefined) would
+    // return the whole document and could be misread as an offset)
     let offset: number = 0;
-    // if second selection is a number jump to offset
-    if (isNumeric(parseInt(offsetText))) {
-        offset = parseInt(offsetText);
-    } else if (selections.length > 1) {
-        vscode.window.showWarningMessage("The second selection could not be interpreted as offset. Jumping to start of file.");
+    if (selections.length > 1) {
+        const offsetText = document.getText(selections[1]).trim();
+        // if second selection is a number jump to offset
+        if (isNumeric(parseInt(offsetText, 10))) {
+            offset = parseInt(offsetText, 10);
+        } else {
+            vscode.window.showWarningMessage("The second selection could not be interpreted as offset. Jumping to start of file.");
+        }
     }
 
     // open doc with uri and set cursor to offset
@@ -134,8 +137,10 @@ export async function goToPosition(): Promise<void> {
                 .showInputBox({
                     prompt: `Type an offset number from 0 to ${maxOffset}.`,
                     validateInput: (input: string) => {
-                        if (!isNumeric(parseFloat(String(input))) || parseFloat(String(input)) > maxOffset || parseFloat(String(input)) < 0) {
-                            return "Number must be between 0 and " + maxOffset + ".";
+                        const trimmed = input.trim();
+                        // only accept non-negative integers; parseFloat would accept "12.5"/"12abc"
+                        if (!/^\d+$/.test(trimmed) || parseInt(trimmed, 10) > maxOffset) {
+                            return "Number must be an integer between 0 and " + maxOffset + ".";
                         } else {
                             return null;
                         }
@@ -144,7 +149,7 @@ export async function goToPosition(): Promise<void> {
                 })
                 .then((input?: string) => {
                     if (input) {
-                        setCursorPosition(parseFloat(String(input)));
+                        setCursorPosition(parseInt(input.trim(), 10));
                     }
                 });
         }

--- a/src/util/findTFS.ts
+++ b/src/util/findTFS.ts
@@ -47,7 +47,9 @@ export function findNextTFS(): boolean {
 
 export function findAllToolCalls(): any {
     let params = {
-        query: "(?<![\w\d])T[0-9]+",
+        // backslashes must be escaped in a normal string literal, otherwise "\w"/"\d" collapse to
+        // the literal letters "w"/"d" and the lookbehind stops excluding word characters/digits
+        query: "(?<![\\w\\d])T[0-9]+",
         triggerSearch: true,
         isRegex: true,
         isCaseSensitive: true,

--- a/src/util/formatter.ts
+++ b/src/util/formatter.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
 import { getEnableFormatter } from './config';
-import { Match } from '../../server/src/parserClasses';
-import { ParseResults } from '../../server/src/parsingResults';
-// Blocknumber regex
-const regExpBlocknumbers = new RegExp(/^((\s?)((\/)|(\/[1-9]{0,2}))*?(\s*?)N[0-9]*(\s?))/);
-const regExpLabels = new RegExp(/(\s?)N[0-9]*:{1}(\s?)|\[.*\]:{1}/);
+import { Match, ParseResults } from '../shared/languageServer';
+import { regExpBlocknumbers, regExpLabels } from './ncBlockRegex';
 
 export class DocumentRangeFormattingEditProvider implements vscode.DocumentRangeFormattingEditProvider {
     provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions): vscode.ProviderResult<vscode.TextEdit[]> {
@@ -106,11 +103,11 @@ export class DocumentRangeFormattingEditProvider implements vscode.DocumentRange
                 currentLine.indexOf("$WHILE") === 0 ||
                 currentLine.indexOf("#VAR") === 0
             ) {
-                // Einfügen der Zeile an aktueller Position, danach wird die aktuelle Position um die TabSize erhöht
+                // insert the line at the current position, then increase the current position by tabSize
                 newLine = newLineForBeautifier(currentLine, currentPos);
                 currentPos = currentPos + whiteSpaces;
             } else if (currentLine.indexOf("$SWITCH") === 0) {
-                // Einfügen der Zeile an aktueller Position, danach wird die aktuelle Position um die TabSize erhöht
+                // insert the line at the current position, then increase the current position by tabSize
                 newLine = newLineForBeautifier(currentLine, currentPos);
                 currentPos = currentPos + whiteSpaces * 2;
             } else if (
@@ -121,14 +118,14 @@ export class DocumentRangeFormattingEditProvider implements vscode.DocumentRange
                 currentLine.indexOf("$ENDWHILE") === 0 ||
                 currentLine.indexOf("#ENDVAR") === 0
             ) {
-                // Aktuelle Position wird um TabSize verringert, danach wird die Zeile an der neuen Position eingefügt
+                // decrease the current position by tabSize, then insert the line at the new position
                 currentPos = currentPos - whiteSpaces;
                 if (currentPos < 0) {
                     currentPos = 0;
                 }
                 newLine = newLineForBeautifier(currentLine, currentPos);
             } else if (currentLine.indexOf("$ENDSWITCH") === 0) {
-                // Aktuelle Position wird um TabSize verringert, danach wird die Zeile an der neuen Position eingefügt
+                // decrease the current position by tabSize, then insert the line at the new position
                 currentPos = currentPos - whiteSpaces * 2;
                 if (currentPos < 0) {
                     currentPos = 0;

--- a/src/util/ncBlockRegex.ts
+++ b/src/util/ncBlockRegex.ts
@@ -1,0 +1,8 @@
+// Shared regular expressions for recognizing block numbers and labels in NC code.
+// Kept in one place so the formatter and the block-number commands stay in sync.
+
+/** Matches an N-blocknumber label (e.g. "N10:") or a bracket label (e.g. "[start]:"). */
+export const regExpLabels = new RegExp(/(\s?)N[0-9]*:{1}(\s?)|\[.*\]:{1}/);
+
+/** Matches a leading block number, optionally preceded by skip-block markers (e.g. "/1 N10"). */
+export const regExpBlocknumbers = new RegExp(/^((\s?)((\/)|(\/[1-9]{0,2}))*?(\s*?)N[0-9]*(\s?))/);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 	"typedocOptions": {
 		"entryPoints": [
 			"server/src/server.ts",
-			"src/util/blowfish/blowfishIntegration.ts",
+			"src/util/encryption/encryption.ts",
 			"src/extension.ts"
 		],
 		"out": "docs"


### PR DESCRIPTION
Fix correctness, performance and security issues across client, server and grammar

## Description

Fixes a range of correctness, performance and security issues across the client, the language server, the grammar and the tooling. All changes are behavior-preserving for existing functionality; the full test suite stays green.

**Client correctness**
- `blockNumbers`: fix off-by-one that deleted a character after compact block numbers (`N10G01` → `01`), fix the comment-line regex range, insert block numbers after multi-character skip markers (`/1`..`/10`), fix the padding width, use a `Set` to avoid O(n²) comment numbering
- `aligning`: only align a real assignment `=`, never comparison operators (`==`, `<=`, `>=`, `!=`)
- `formatter`: extract the shared block-number/label regex
- `findTFS`: escape the lookbehind so `\w`/`\d` are not collapsed to `w`/`d`
- `fileoffset`: guard `selections[1]`; validate offsets as integers
- `fileContentTree`: read the file once per tree update, split EOL-agnostic, await the update, drop never-resolving promises, debounce `fs.watch`
- `documentation`: validate the documentation id against path traversal, drop dead code
- `extension`: catch language client start errors, return `client.stop()` from `deactivate`

**Server correctness**
- reference/definition search: skip unparseable files instead of aborting the whole search, always close the progress bar, cross-platform absolute-path handling
- `stringSearching`: opt-in whole-word variable matching (trailing boundary only, so NC address words preceding a variable such as the `X` in `XV.L.VAR` still count as references), allow dots in variable names, reuse already-parsed comments
- `config`: remove the duplicated `updateSettings` block, guard config access
- `fileSystem`: case-insensitive file match on Windows, skip heavy directories (`.git`, `node_modules`, …)

**Security**
- restrict trusted markdown to `isg-cnc.openDocuWithId` and escape file-derived hover text; use `crypto.randomBytes` for padding; document the Blowfish/interop rationale in the README

**Performance**
- content-keyed parse cache reused across completion/hover/definition/references
- async reference search so cancellation can take effect
- shallow-copy completions instead of a full JSON deep copy per request
- reuse the workspace ignorer during the recursive scan

**Grammar/parser**
- reachable skip level `/10` and `STRING[100]`/`STRING[110]`; regenerate `ncParser.ts`; make `generateParser` fail loudly on error

**Architecture**
- route the client's parser imports through a single explicit boundary module (`src/shared/languageServer.ts`)

**Tooling/CI**
- update GitHub Actions (add `workflow_dispatch`, current action versions), add a release test gate, lint `src` + `server/src` with `--max-warnings 0`, add `dependabot.yml`, fix the test-bootstrap extension id, add a `generateParser` npm script, add Blowfish encryption tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Full extension test suite (`npm test`) passes on the 3-OS GitHub Actions matrix (Windows / Linux / macOS)
- [x] `tsc` (client + server) and `eslint src server/src --ext ts --max-warnings 0` are clean
- [x] Added Blowfish encryption round-trip/golden-vector tests

**Test Configuration**:
* Node: 20
* VS Code: 1.128 (via `@vscode/test-electron`)
* OS: windows-latest / ubuntu-latest / macos-latest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes